### PR TITLE
fix(rust): fix CI/CD release pipeline not publishing to crates.io

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -279,9 +279,9 @@ jobs:
           # Check if version is published on crates.io (the source of truth for Rust packages)
           # Note: We check crates.io, not git tags, because git tags can exist without
           # the package being published (e.g., failed publish, GitHub-only releases)
-          CRATES_IO_RESPONSE=$(curl -s "https://crates.io/api/v1/crates/${CRATE_NAME}/${CURRENT_VERSION}")
+          CRATES_IO_RESPONSE=$(curl -s -H "User-Agent: browser-commander CI (github.com/link-foundation/browser-commander)" "https://crates.io/api/v1/crates/${CRATE_NAME}/${CURRENT_VERSION}")
           VERSION_ON_CRATES_IO=false
-          if echo "$CRATES_IO_RESPONSE" | grep -q '"version"'; then
+          if echo "$CRATES_IO_RESPONSE" | grep -q '"num"'; then
             VERSION_ON_CRATES_IO=true
           fi
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-13T02:26:19.146Z for PR creation at branch issue-47-e0d425c48e8d for issue https://github.com/link-foundation/browser-commander/issues/47

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-13T02:26:19.146Z for PR creation at branch issue-47-e0d425c48e8d for issue https://github.com/link-foundation/browser-commander/issues/47

--- a/docs/case-studies/issue-47/analysis.md
+++ b/docs/case-studies/issue-47/analysis.md
@@ -1,0 +1,90 @@
+# Case Study: Rust CI/CD Release Pipeline Failure (Issue #47)
+
+## Timeline of Events
+
+1. **2025-12-28**: Versions 0.1.1 through 0.4.0 released successfully (both crates.io and GitHub releases working)
+2. **2026-01-18**: Version 0.4.0 published to crates.io (last successful crates.io publish)
+3. **2026-01-18 to 2026-04-06**: Multiple CI runs succeed (lint, test, build pass), but auto-release creates GitHub releases (v0.5.0 through v0.8.0) WITHOUT publishing to crates.io
+4. **2026-04-06**: Version 0.8.0 released on GitHub, but crates.io still shows only 0.4.0
+
+## Root Cause Analysis
+
+### Primary Root Cause: Tag-based vs crates.io-based release detection mismatch
+
+The release pipeline has two conflicting sources of truth:
+
+1. **`auto-release` check step** (workflow line 273-305): Correctly checks **crates.io** to determine if the current version is published
+2. **`version-and-commit.mjs`** (line 127-134): Checks **git tags** to determine if a version was already released
+
+This creates a failure loop:
+
+```
+Step 1: auto-release reads Cargo.toml → version 0.4.0
+Step 2: auto-release checks crates.io for 0.4.0 → EXISTS (published Jan 18)
+Step 3: Changelog fragments exist → should_release=true, skip_bump=false
+Step 4: version-and-commit.mjs bumps 0.4.0 → 0.4.1
+Step 5: version-and-commit.mjs checks tag v0.4.1 → EXISTS (from prior GitHub release)
+Step 6: version-and-commit.mjs exits early WITHOUT updating Cargo.toml
+Step 7: Cargo.toml still says 0.4.0
+Step 8: cargo publish tries 0.4.0 → "already exists on crates.io index"
+Step 9: publish-crate.mjs treats "already exists" as SUCCESS (masking the failure)
+Step 10: create-github-release tries v0.4.0 → HTTP 422 "already_exists"
+Step 11: create-github-release treats 422 as success (masking the failure)
+```
+
+### Contributing Factors
+
+1. **Silent error masking**: Both `publish-crate.mjs` and `create-github-release.mjs` treat "already exists" errors as success, hiding the fact that no new version was actually released
+2. **No version synchronization**: Cargo.toml version (0.4.0) became permanently out of sync with GitHub releases (v0.8.0) because the version bump commit was never pushed
+3. **Tag pollution**: GitHub releases created tags (v0.4.1 through v0.8.0) that block future version bumps since `version-and-commit.mjs` considers any existing tag as "already released"
+4. **Deprecated `set-output` usage**: The script uses `::set-output` (deprecated) alongside `$GITHUB_OUTPUT`, generating warnings but not causing failures
+
+### Evidence from CI Logs
+
+From run `24052845183` (2026-04-06):
+```
+Line 4648: Crate: browser-commander, Version: 0.4.0, Published on crates.io: false
+Line 4660: fatal: ambiguous argument 'v0.4.1': unknown revision or path not in the working tree.
+Line 4664: Tag v0.4.1 already exists
+Line 5095: Package: browser-commander@0.4.0
+Line 5100: error: crate browser-commander@0.4.0 already exists on crates.io index
+Line 5101: Successfully published browser-commander@0.4.0 to crates.io   ← MASKED ERROR
+Line 5116: gh: Validation Failed (HTTP 422)                                ← MASKED ERROR
+```
+
+Note: Line 4648 reports `Published on crates.io: false` because the crates.io API response format check (`grep -q '"version"'`) may have matched incorrectly, or there was a transient API issue. Regardless, the version-and-commit.mjs tag check is the blocking issue.
+
+## Solutions Implemented
+
+### Fix 1: Check crates.io instead of git tags in version-and-commit.mjs
+
+Replace `checkTagExists()` with `checkVersionOnCratesIo()` that queries the crates.io API. This aligns the script with the same source of truth used by the auto-release check step.
+
+### Fix 2: Skip tag check when version bump was explicitly requested
+
+When the auto-release job determines fragments exist and a bump is needed, version-and-commit.mjs should find the next available version that hasn't been published to crates.io, rather than being blocked by git tags.
+
+### Fix 3: Bump Cargo.toml to next unpublished version
+
+Since tags v0.4.1 through v0.8.0 exist but crates.io only has 0.4.0, we need to advance the Cargo.toml version past all existing tags to a version that hasn't been used.
+
+### Fix 4: Remove deprecated set-output usage
+
+Replace `::set-output` with `$GITHUB_OUTPUT` file writes exclusively.
+
+## Comparison with Reference Repositories
+
+| Feature | browser-commander | lino-arguments | Numbers | Template |
+|---------|-------------------|----------------|---------|----------|
+| Release source of truth | Git tags (broken) | Git tags + crates.io | Reusable workflows | crates.io |
+| Error masking | Yes (silent) | Better error reporting | N/A | Better |
+| Tag prefixes | None (collision risk) | `js_`, `rust_` | Mixed | Standardized |
+| Version modification PR check | No | Yes | No | No |
+| Rust code coverage | No | No | Yes (cargo-llvm-cov) | No |
+
+## Recommendations
+
+1. **Immediate**: Fix version-and-commit.mjs to check crates.io, bump Cargo.toml version
+2. **Short-term**: Add tag prefixes (`rust-v`) to avoid cross-language tag collisions
+3. **Medium-term**: Add cargo-llvm-cov for Rust code coverage (per Numbers repo)
+4. **Long-term**: Consider reusable workflows (per Numbers/linksplatform pattern)

--- a/experiments/test-crates-io-check.mjs
+++ b/experiments/test-crates-io-check.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify the crates.io version check logic
+ * used by version-and-commit.mjs
+ */
+
+async function checkVersionOnCratesIo(crateName, version) {
+  try {
+    const response = await fetch(
+      `https://crates.io/api/v1/crates/${crateName}/${version}`,
+      {
+        headers: {
+          'User-Agent': 'browser-commander-test (github.com/link-foundation/browser-commander)',
+        },
+      }
+    );
+    if (response.ok) {
+      const data = await response.json();
+      return Boolean(data.version);
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  console.log('Testing crates.io version check...\n');
+
+  const tests = [
+    // Should be true - published version
+    { crate: 'browser-commander', version: '0.4.0', expected: true },
+    // Should be false - never published
+    { crate: 'browser-commander', version: '0.5.0', expected: false },
+    { crate: 'browser-commander', version: '0.8.0', expected: false },
+    { crate: 'browser-commander', version: '0.9.0', expected: false },
+    // Should be false - non-existent crate
+    { crate: 'nonexistent-crate-xyz-123', version: '1.0.0', expected: false },
+    // Known popular crate for sanity check
+    { crate: 'serde', version: '1.0.0', expected: true },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const test of tests) {
+    const result = await checkVersionOnCratesIo(test.crate, test.version);
+    const status = result === test.expected ? 'PASS' : 'FAIL';
+
+    if (status === 'PASS') passed++;
+    else failed++;
+
+    console.log(
+      `${status}: ${test.crate}@${test.version} - expected=${test.expected}, got=${result}`
+    );
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed out of ${tests.length} tests`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/experiments/test-next-version.mjs
+++ b/experiments/test-next-version.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify the findNextAvailableVersion logic
+ */
+
+async function checkVersionOnCratesIo(crateName, version) {
+  try {
+    const response = await fetch(
+      `https://crates.io/api/v1/crates/${crateName}/${version}`,
+      {
+        headers: {
+          'User-Agent': 'browser-commander-test (github.com/link-foundation/browser-commander)',
+        },
+      }
+    );
+    if (response.ok) {
+      const data = await response.json();
+      return Boolean(data.version);
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function calculateNewVersion(current, bumpType) {
+  const { major, minor, patch } = current;
+  switch (bumpType) {
+    case 'major': return `${major + 1}.0.0`;
+    case 'minor': return `${major}.${minor + 1}.0`;
+    case 'patch': return `${major}.${minor}.${patch + 1}`;
+    default: throw new Error(`Invalid bump type: ${bumpType}`);
+  }
+}
+
+async function findNextAvailableVersion(crateName, current, bumpType) {
+  let version = calculateNewVersion(current, bumpType);
+
+  while (await checkVersionOnCratesIo(crateName, version)) {
+    console.log(`  Version ${version} already published on crates.io, trying next...`);
+    const parts = version.split('.').map(Number);
+    const next = { major: parts[0], minor: parts[1], patch: parts[2] };
+    version = calculateNewVersion(next, 'patch');
+  }
+
+  return version;
+}
+
+async function main() {
+  console.log('Testing findNextAvailableVersion...\n');
+
+  // Test 1: Starting from 0.4.0 (which IS published), patch bump should find 0.4.1
+  console.log('Test 1: From 0.4.0, patch bump (0.4.0 is published, 0.4.1 is not)');
+  const v1 = await findNextAvailableVersion('browser-commander', { major: 0, minor: 4, patch: 0 }, 'patch');
+  console.log(`  Result: ${v1}`);
+  console.log(`  ${v1 === '0.4.1' ? 'PASS' : 'FAIL'}: expected 0.4.1\n`);
+
+  // Test 2: Starting from 0.8.0 (NOT published), minor bump should find 0.9.0
+  console.log('Test 2: From 0.8.0, minor bump (0.9.0 is not published)');
+  const v2 = await findNextAvailableVersion('browser-commander', { major: 0, minor: 8, patch: 0 }, 'minor');
+  console.log(`  Result: ${v2}`);
+  console.log(`  ${v2 === '0.9.0' ? 'PASS' : 'FAIL'}: expected 0.9.0\n`);
+
+  // Test 3: serde has many versions, patch from 1.0.0 should skip past published ones
+  console.log('Test 3: serde from 1.0.0, patch bump (many versions published)');
+  const v3 = await findNextAvailableVersion('serde', { major: 1, minor: 0, patch: 0 }, 'patch');
+  console.log(`  Result: ${v3}`);
+  const v3Parts = v3.split('.').map(Number);
+  console.log(`  ${v3Parts[2] > 1 ? 'PASS' : 'FAIL'}: should skip past published versions\n`);
+
+  console.log('All tests completed.');
+}
+
+main();

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "browser-commander"
-version = "0.4.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "browser-commander"
-version = "0.4.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Link Foundation"]
 description = "Universal browser automation library that supports multiple browser engines with a unified API"

--- a/rust/scripts/publish-crate.mjs
+++ b/rust/scripts/publish-crate.mjs
@@ -152,7 +152,7 @@ async function main() {
         errorMessage.includes('already exists')
       ) {
         console.log(
-          `Version ${version} already exists on crates.io - this is OK`
+          `::warning::Version ${version} already exists on crates.io - no new version was published`
         );
         setOutput('publish_result', 'already_exists');
       } else {

--- a/rust/scripts/version-and-commit.mjs
+++ b/rust/scripts/version-and-commit.mjs
@@ -127,7 +127,12 @@ function updateCargoToml(newVersion) {
 async function checkVersionOnCratesIo(crateName, version) {
   try {
     const response = await fetch(
-      `https://crates.io/api/v1/crates/${crateName}/${version}`
+      `https://crates.io/api/v1/crates/${crateName}/${version}`,
+      {
+        headers: {
+          'User-Agent': 'browser-commander-ci (github.com/link-foundation/browser-commander)',
+        },
+      }
     );
     if (response.ok) {
       const data = await response.json();
@@ -147,9 +152,17 @@ async function checkVersionOnCratesIo(crateName, version) {
  * @returns {Promise<string>}
  */
 async function findNextAvailableVersion(crateName, current, bumpType) {
+  const MAX_ATTEMPTS = 20;
   let version = calculateNewVersion(current, bumpType);
+  let attempts = 0;
 
   while (await checkVersionOnCratesIo(crateName, version)) {
+    attempts++;
+    if (attempts >= MAX_ATTEMPTS) {
+      throw new Error(
+        `Could not find an available version after ${MAX_ATTEMPTS} attempts (last tried: ${version})`
+      );
+    }
     console.log(`Version ${version} already published on crates.io, trying next...`);
     const parts = version.split('.').map(Number);
     const next = { major: parts[0], minor: parts[1], patch: parts[2] };

--- a/rust/scripts/version-and-commit.mjs
+++ b/rust/scripts/version-and-commit.mjs
@@ -60,8 +60,7 @@ function setOutput(key, value) {
   if (outputFile) {
     appendFileSync(outputFile, `${key}=${value}\n`);
   }
-  // Also log for visibility
-  console.log(`::set-output name=${key}::${value}`);
+  console.log(`Output: ${key}=${value}`);
 }
 
 /**
@@ -120,17 +119,44 @@ function updateCargoToml(newVersion) {
 }
 
 /**
- * Check if a git tag exists for this version
+ * Check if a version is published on crates.io
+ * @param {string} crateName
  * @param {string} version
  * @returns {Promise<boolean>}
  */
-async function checkTagExists(version) {
+async function checkVersionOnCratesIo(crateName, version) {
   try {
-    await $`git rev-parse v${version}`.run({ capture: true });
-    return true;
+    const response = await fetch(
+      `https://crates.io/api/v1/crates/${crateName}/${version}`
+    );
+    if (response.ok) {
+      const data = await response.json();
+      return Boolean(data.version);
+    }
+    return false;
   } catch {
     return false;
   }
+}
+
+/**
+ * Find the next available version that is not yet published on crates.io
+ * @param {string} crateName
+ * @param {{major: number, minor: number, patch: number}} current
+ * @param {string} bumpType
+ * @returns {Promise<string>}
+ */
+async function findNextAvailableVersion(crateName, current, bumpType) {
+  let version = calculateNewVersion(current, bumpType);
+
+  while (await checkVersionOnCratesIo(crateName, version)) {
+    console.log(`Version ${version} already published on crates.io, trying next...`);
+    const parts = version.split('.').map(Number);
+    const next = { major: parts[0], minor: parts[1], patch: parts[2] };
+    version = calculateNewVersion(next, 'patch');
+  }
+
+  return version;
 }
 
 /**
@@ -215,15 +241,23 @@ async function main() {
     await $`git config user.email "github-actions[bot]@users.noreply.github.com"`;
 
     const current = getCurrentVersion();
-    const newVersion = calculateNewVersion(current, bumpType);
+    const currentVersionStr = `${current.major}.${current.minor}.${current.patch}`;
 
-    // Check if this version was already released
-    if (await checkTagExists(newVersion)) {
-      console.log(`Tag v${newVersion} already exists`);
-      setOutput('already_released', 'true');
-      setOutput('new_version', newVersion);
-      return;
+    // Get crate name from Cargo.toml
+    const cargoToml = readFileSync('Cargo.toml', 'utf-8');
+    const nameMatch = cargoToml.match(/^name\s*=\s*"([^"]+)"/m);
+    const crateName = nameMatch ? nameMatch[1] : 'unknown';
+
+    // Check if the current version is already published on crates.io
+    if (await checkVersionOnCratesIo(crateName, currentVersionStr)) {
+      console.log(`Current version ${currentVersionStr} is already published on crates.io`);
+    } else {
+      console.log(`Current version ${currentVersionStr} is NOT published on crates.io`);
     }
+
+    // Find the next version that is not yet published on crates.io
+    const newVersion = await findNextAvailableVersion(crateName, current, bumpType);
+    console.log(`Next available version: ${newVersion}`);
 
     // Update version in Cargo.toml
     updateCargoToml(newVersion);


### PR DESCRIPTION
## Summary

Fixes #47 — Rust CI/CD pipeline was stuck at version 0.4.0 on crates.io while GitHub had releases up to v0.8.0.

**Root cause**: `version-and-commit.mjs` checked **git tags** instead of **crates.io** to determine if a version was already released. Since GitHub releases created tags (v0.4.1 through v0.8.0) without corresponding crates.io publishes, the script always found an existing tag and exited early without bumping Cargo.toml. This left the version permanently stuck at 0.4.0.

**Evidence from CI logs** (run 24052845183):
```
Line 4660: fatal: ambiguous argument 'v0.4.1': unknown revision or path not in the working tree.
Line 4664: Tag v0.4.1 already exists
Line 5100: error: crate browser-commander@0.4.0 already exists on crates.io index
Line 5101: Successfully published browser-commander@0.4.0 to crates.io  ← MASKED ERROR
```

## Changes

- **`version-and-commit.mjs`**: Replace git tag check (`git rev-parse`) with crates.io API check to use the registry as the source of truth for published versions
- **`version-and-commit.mjs`**: Add `findNextAvailableVersion()` with safety limit (20 attempts) to find next unpublished version
- **`version-and-commit.mjs`**: Remove deprecated `::set-output` syntax, add User-Agent header for crates.io API
- **`publish-crate.mjs`**: Change "already exists" message to a `::warning::` annotation so it's visible in CI
- **`rust.yml`**: Add User-Agent header to crates.io API call, improve response validation grep pattern
- **`Cargo.toml`**: Bump version to 0.9.0 (past all existing tags v0.4.0–v0.8.0)
- **Case study**: Full root cause analysis with timeline in `docs/case-studies/issue-47/`

## Related issues reported

Same bug exists in upstream repos:
- https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/25
- https://github.com/link-foundation/lino-arguments/issues/35

## Test plan

- [x] All 135 Rust unit tests pass (`cargo test --all-features`)
- [x] All 6 doc tests pass (`cargo test --doc`)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features` passes (with `-Dwarnings`)
- [x] `cargo build --release` succeeds with version 0.9.0
- [x] Experiment script `experiments/test-crates-io-check.mjs` verifies crates.io API check works correctly
- [x] Experiment script `experiments/test-next-version.mjs` verifies version search logic
- [ ] CI pipeline passes on this PR
- [ ] After merge: verify auto-release publishes 0.9.0 to crates.io (requires `CARGO_TOKEN` secret and changelog fragment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)