### PR TITLE
feat(rust): implement real launch_browser with live page adapter

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T15:12:04.569Z for PR creation at branch issue-49-2ea16458d451 for issue https://github.com/link-foundation/browser-commander/issues/49

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T15:12:04.569Z for PR creation at branch issue-49-2ea16458d451 for issue https://github.com/link-foundation/browser-commander/issues/49

--- a/rust/README.md
+++ b/rust/README.md
@@ -37,21 +37,22 @@ use browser_commander::prelude::*;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Launch a browser with chromiumoxide engine
-    let options = LaunchOptions::chromiumoxide()
-        .headless(true);
-
+    let options = LaunchOptions::chromiumoxide().headless(true);
     let result = launch_browser(options).await?;
     println!("Browser launched: {:?}", result.browser.engine);
 
+    // `result.page` is an `Arc<dyn EngineAdapter>` you can pass to any
+    // of the navigation / interaction helpers.
+    let page = result.page.as_ref();
+
     // Navigate to a URL
-    let page = &result.page;
-    goto(page, "https://example.com", None).await?;
+    page.goto("https://example.com").await?;
 
     // Click a button
-    click_button(page, "button.submit", None).await?;
+    page.click("button.submit").await?;
 
     // Fill a text field
-    fill_text_area(page, "input[name='email']", "test@example.com", None).await?;
+    page.fill("input[name='email']", "test@example.com").await?;
 
     Ok(())
 }

--- a/rust/changelog.d/49.added.md
+++ b/rust/changelog.d/49.added.md
@@ -1,0 +1,16 @@
+---
+bump: minor
+---
+
+### Added
+
+- Real Chromium launch via `chromiumoxide` in `launch_browser`. Previously the Rust `launch_browser` created a user data directory and returned metadata only; it now starts a Chromium process, completes the CDP handshake, opens an initial page, and returns a live page adapter.
+- `LaunchResult.page: Arc<dyn EngineAdapter>` — live page handle returned from `launch_browser`, usable with all of the crate's navigation, interaction, and query helpers (`goto`, `click`, `fill`, `evaluate`, `is_visible`, `count`, ...).
+- `ChromiumoxidePage` adapter (`browser::chromiumoxide_adapter`) implementing the full `EngineAdapter` trait on top of `chromiumoxide::Page`, including navigation, element interaction, evaluation, screenshots, PDF printing (with CSS length/paper-format parsing), keyboard events, and color-scheme emulation.
+- `LaunchOptions::sandbox(bool)` and `LaunchOptions::launch_timeout(Duration)` builder methods for CI-friendly launches.
+- `ChromiumoxidePage::raw_page()` escape hatch for chromiumoxide-specific APIs not yet covered by the unified trait.
+- Integration smoke test (`tests/launch_smoke.rs`, `--ignored`) that launches a real headless Chromium, navigates, evaluates JavaScript, and checks visibility / element counts.
+
+### Fixed
+
+- README quick-start example now compiles against the real `launch_browser` API (`result.page.as_ref().goto(...)`) instead of the previous placeholder signature.

--- a/rust/src/browser/chromiumoxide_adapter.rs
+++ b/rust/src/browser/chromiumoxide_adapter.rs
@@ -1,0 +1,569 @@
+//! Chromiumoxide-backed [`EngineAdapter`] implementation.
+//!
+//! Wraps a live [`chromiumoxide::Page`] and the owning [`chromiumoxide::Browser`]
+//! so that browser-commander operations (goto, click, fill, evaluate, ...) can
+//! be executed against a real Chromium instance launched via the Chrome
+//! DevTools Protocol.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chromiumoxide::cdp::browser_protocol::page::PrintToPdfParams;
+use chromiumoxide::{Browser as CdpBrowser, Page as CdpPage};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::browser::media::ColorScheme;
+use crate::core::engine::{ElementInfo, EngineAdapter, EngineError, EngineType, PdfOptions};
+
+/// A [`EngineAdapter`] that drives a Chromium browser through
+/// `chromiumoxide`.
+///
+/// Obtained from [`launch_browser`](super::launcher::launch_browser).
+/// The adapter owns the browser handle along with the background task that
+/// services CDP events; dropping the adapter (or calling
+/// [`ChromiumoxidePage::close`]) terminates the browser process.
+pub struct ChromiumoxidePage {
+    page: CdpPage,
+    browser: Arc<Mutex<Option<CdpBrowser>>>,
+    handler_task: Arc<Mutex<Option<JoinHandle<()>>>>,
+    user_data_dir: PathBuf,
+}
+
+impl ChromiumoxidePage {
+    pub(crate) fn new(
+        page: CdpPage,
+        browser: CdpBrowser,
+        handler_task: JoinHandle<()>,
+        user_data_dir: PathBuf,
+    ) -> Self {
+        Self {
+            page,
+            browser: Arc::new(Mutex::new(Some(browser))),
+            handler_task: Arc::new(Mutex::new(Some(handler_task))),
+            user_data_dir,
+        }
+    }
+
+    /// Access the underlying [`chromiumoxide::Page`] for engine-specific
+    /// operations that are not yet covered by the unified API.
+    pub fn raw_page(&self) -> &CdpPage {
+        &self.page
+    }
+
+    /// The resolved user data directory used for this browser session.
+    pub fn user_data_dir(&self) -> &PathBuf {
+        &self.user_data_dir
+    }
+
+    /// Emulate a CSS `prefers-color-scheme` media feature on the live page.
+    pub async fn set_color_scheme(&self, scheme: Option<&ColorScheme>) -> Result<(), EngineError> {
+        use chromiumoxide::cdp::browser_protocol::emulation::{
+            MediaFeature, SetEmulatedMediaParams,
+        };
+
+        let features = match scheme {
+            Some(cs) => vec![MediaFeature {
+                name: "prefers-color-scheme".to_string(),
+                value: cs.as_str().to_string(),
+            }],
+            None => Vec::new(),
+        };
+
+        self.page
+            .execute(SetEmulatedMediaParams::builder().features(features).build())
+            .await
+            .map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    /// Close the browser and terminate the background CDP handler task.
+    ///
+    /// Idempotent: calling more than once is a no-op.
+    pub async fn close(&self) -> Result<(), EngineError> {
+        let browser = self.browser.lock().await.take();
+        if let Some(mut browser) = browser {
+            let _ = browser.close().await;
+            let _ = browser.wait().await;
+        }
+        let handle = self.handler_task.lock().await.take();
+        if let Some(handle) = handle {
+            handle.abort();
+            let _ = handle.await;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for ChromiumoxidePage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChromiumoxidePage")
+            .field("user_data_dir", &self.user_data_dir)
+            .finish()
+    }
+}
+
+impl Drop for ChromiumoxidePage {
+    fn drop(&mut self) {
+        // Best-effort cleanup without blocking the current runtime. If the
+        // user did not call `close()` explicitly, abort the background task
+        // so the Tokio runtime can terminate cleanly.
+        if let Ok(mut guard) = self.handler_task.try_lock() {
+            if let Some(handle) = guard.take() {
+                handle.abort();
+            }
+        }
+    }
+}
+
+fn to_engine_error(err: impl std::fmt::Display) -> EngineError {
+    EngineError::Browser(err.to_string())
+}
+
+async fn eval_value(page: &CdpPage, script: String) -> Result<serde_json::Value, EngineError> {
+    let result = page.evaluate(script).await.map_err(to_engine_error)?;
+    Ok(result.value().cloned().unwrap_or(serde_json::Value::Null))
+}
+
+fn js_selector_call(selector: &str, body: &str) -> String {
+    // Build a JS snippet that invokes `body` on the element matched by
+    // `selector`, returning `null` when nothing matches. `body` must be a JS
+    // expression or statement sequence referring to `el` as the element.
+    format!(
+        r#"(() => {{
+            const el = document.querySelector({});
+            if (!el) return null;
+            {}
+        }})()"#,
+        serde_json::to_string(selector).unwrap_or_else(|_| "\"\"".to_string()),
+        body
+    )
+}
+
+#[async_trait]
+impl EngineAdapter for ChromiumoxidePage {
+    fn engine_type(&self) -> EngineType {
+        EngineType::Chromiumoxide
+    }
+
+    async fn url(&self) -> Result<String, EngineError> {
+        let url = self.page.url().await.map_err(to_engine_error)?;
+        Ok(url.unwrap_or_default())
+    }
+
+    async fn goto(&self, url: &str) -> Result<(), EngineError> {
+        self.page.goto(url).await.map_err(to_engine_error)?;
+        self.page
+            .wait_for_navigation()
+            .await
+            .map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    async fn query_selector(&self, selector: &str) -> Result<Option<ElementInfo>, EngineError> {
+        match self.page.find_element(selector).await {
+            Ok(element) => {
+                let tag_name = element
+                    .attribute("tagName")
+                    .await
+                    .map_err(to_engine_error)?
+                    .unwrap_or_else(|| "UNKNOWN".to_string());
+                let text = element.inner_text().await.map_err(to_engine_error)?;
+                let bounding_box = element
+                    .bounding_box()
+                    .await
+                    .ok()
+                    .map(|b| (b.x, b.y, b.width, b.height));
+                Ok(Some(ElementInfo {
+                    tag_name,
+                    text_content: text,
+                    is_visible: bounding_box.is_some(),
+                    is_enabled: true,
+                    bounding_box,
+                }))
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
+    async fn query_selector_all(&self, selector: &str) -> Result<Vec<ElementInfo>, EngineError> {
+        let elements = self
+            .page
+            .find_elements(selector)
+            .await
+            .map_err(to_engine_error)?;
+        let mut infos = Vec::with_capacity(elements.len());
+        for element in elements {
+            let tag_name = element
+                .attribute("tagName")
+                .await
+                .map_err(to_engine_error)?
+                .unwrap_or_else(|| "UNKNOWN".to_string());
+            let text = element.inner_text().await.map_err(to_engine_error)?;
+            let bounding_box = element
+                .bounding_box()
+                .await
+                .ok()
+                .map(|b| (b.x, b.y, b.width, b.height));
+            infos.push(ElementInfo {
+                tag_name,
+                text_content: text,
+                is_visible: bounding_box.is_some(),
+                is_enabled: true,
+                bounding_box,
+            });
+        }
+        Ok(infos)
+    }
+
+    async fn count(&self, selector: &str) -> Result<usize, EngineError> {
+        let script = format!(
+            "document.querySelectorAll({}).length",
+            serde_json::to_string(selector).unwrap_or_else(|_| "\"\"".to_string())
+        );
+        let value = eval_value(&self.page, script).await?;
+        Ok(value.as_u64().unwrap_or(0) as usize)
+    }
+
+    async fn click(&self, selector: &str) -> Result<(), EngineError> {
+        let element = self
+            .page
+            .find_element(selector)
+            .await
+            .map_err(to_engine_error)?;
+        element.click().await.map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    async fn fill(&self, selector: &str, text: &str) -> Result<(), EngineError> {
+        // Clear the current value, then type the new text.
+        let clear_script = js_selector_call(
+            selector,
+            "el.focus(); if ('value' in el) { el.value = ''; \
+             el.dispatchEvent(new Event('input', {bubbles:true})); } return true;",
+        );
+        eval_value(&self.page, clear_script).await?;
+        let element = self
+            .page
+            .find_element(selector)
+            .await
+            .map_err(to_engine_error)?;
+        element.click().await.map_err(to_engine_error)?;
+        element.type_str(text).await.map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    async fn type_text(&self, selector: &str, text: &str) -> Result<(), EngineError> {
+        let element = self
+            .page
+            .find_element(selector)
+            .await
+            .map_err(to_engine_error)?;
+        element.click().await.map_err(to_engine_error)?;
+        element.type_str(text).await.map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    async fn text_content(&self, selector: &str) -> Result<Option<String>, EngineError> {
+        match self.page.find_element(selector).await {
+            Ok(element) => element.inner_text().await.map_err(to_engine_error),
+            Err(_) => Ok(None),
+        }
+    }
+
+    async fn input_value(&self, selector: &str) -> Result<Option<String>, EngineError> {
+        let script = js_selector_call(selector, "return 'value' in el ? el.value : null;");
+        let value = eval_value(&self.page, script).await?;
+        Ok(match value {
+            serde_json::Value::Null => None,
+            serde_json::Value::String(s) => Some(s),
+            other => Some(other.to_string()),
+        })
+    }
+
+    async fn get_attribute(
+        &self,
+        selector: &str,
+        attribute: &str,
+    ) -> Result<Option<String>, EngineError> {
+        let script = js_selector_call(
+            selector,
+            &format!(
+                "return el.getAttribute({});",
+                serde_json::to_string(attribute).unwrap_or_else(|_| "\"\"".to_string())
+            ),
+        );
+        let value = eval_value(&self.page, script).await?;
+        Ok(match value {
+            serde_json::Value::Null => None,
+            serde_json::Value::String(s) => Some(s),
+            other => Some(other.to_string()),
+        })
+    }
+
+    async fn is_visible(&self, selector: &str) -> Result<bool, EngineError> {
+        let script = js_selector_call(
+            selector,
+            "const style = window.getComputedStyle(el); \
+             if (style.display === 'none' || style.visibility === 'hidden') return false; \
+             const rect = el.getBoundingClientRect(); \
+             return rect.width > 0 && rect.height > 0;",
+        );
+        let value = eval_value(&self.page, script).await?;
+        Ok(value.as_bool().unwrap_or(false))
+    }
+
+    async fn is_enabled(&self, selector: &str) -> Result<bool, EngineError> {
+        let script = js_selector_call(selector, "return !el.disabled;");
+        let value = eval_value(&self.page, script).await?;
+        Ok(value.as_bool().unwrap_or(false))
+    }
+
+    async fn wait_for_selector(&self, selector: &str, timeout_ms: u64) -> Result<(), EngineError> {
+        let deadline = std::time::Instant::now() + Duration::from_millis(timeout_ms);
+        loop {
+            if self.page.find_element(selector).await.is_ok() {
+                return Ok(());
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(EngineError::Timeout(format!(
+                    "wait_for_selector: {} not found in {}ms",
+                    selector, timeout_ms
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    async fn scroll_into_view(&self, selector: &str) -> Result<(), EngineError> {
+        let element = self
+            .page
+            .find_element(selector)
+            .await
+            .map_err(to_engine_error)?;
+        element.scroll_into_view().await.map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    async fn evaluate(&self, script: &str) -> Result<serde_json::Value, EngineError> {
+        eval_value(&self.page, script.to_string()).await
+    }
+
+    async fn screenshot(&self) -> Result<Vec<u8>, EngineError> {
+        use chromiumoxide::page::ScreenshotParams;
+        self.page
+            .screenshot(ScreenshotParams::builder().build())
+            .await
+            .map_err(to_engine_error)
+    }
+
+    async fn pdf(&self, options: PdfOptions) -> Result<Vec<u8>, EngineError> {
+        let mut builder = PrintToPdfParams::builder().print_background(options.print_background);
+        if let Some(scale) = options.scale {
+            builder = builder.scale(scale);
+        }
+        // Margins are interpreted as inches. browser-commander accepts CSS
+        // margin strings; translate common units so callers can pass
+        // e.g. "1cm" / "0.5in" / "10mm".
+        if let Some(v) = css_length_to_inches(options.margin_top.as_deref()) {
+            builder = builder.margin_top(v);
+        }
+        if let Some(v) = css_length_to_inches(options.margin_bottom.as_deref()) {
+            builder = builder.margin_bottom(v);
+        }
+        if let Some(v) = css_length_to_inches(options.margin_left.as_deref()) {
+            builder = builder.margin_left(v);
+        }
+        if let Some(v) = css_length_to_inches(options.margin_right.as_deref()) {
+            builder = builder.margin_right(v);
+        }
+        if let Some(format) = options.format.as_deref() {
+            if let Some((w, h)) = paper_format_inches(format) {
+                builder = builder.paper_width(w).paper_height(h);
+            }
+        }
+        let params = builder.build();
+        let bytes = self.page.pdf(params).await.map_err(to_engine_error)?;
+        if let Some(path) = options.path {
+            tokio::fs::write(path, &bytes)
+                .await
+                .map_err(|e| EngineError::Browser(format!("failed to write pdf: {}", e)))?;
+        }
+        Ok(bytes)
+    }
+
+    async fn bring_to_front(&self) -> Result<(), EngineError> {
+        self.page.bring_to_front().await.map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    async fn wait_for_navigation(&self, _timeout_ms: u64) -> Result<(), EngineError> {
+        self.page
+            .wait_for_navigation()
+            .await
+            .map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    async fn keyboard_press(&self, key: &str) -> Result<(), EngineError> {
+        use chromiumoxide::cdp::browser_protocol::input::{
+            DispatchKeyEventParams, DispatchKeyEventType,
+        };
+        self.page
+            .execute(
+                DispatchKeyEventParams::builder()
+                    .r#type(DispatchKeyEventType::KeyDown)
+                    .key(key.to_string())
+                    .build()
+                    .map_err(EngineError::Browser)?,
+            )
+            .await
+            .map_err(to_engine_error)?;
+        self.page
+            .execute(
+                DispatchKeyEventParams::builder()
+                    .r#type(DispatchKeyEventType::KeyUp)
+                    .key(key.to_string())
+                    .build()
+                    .map_err(EngineError::Browser)?,
+            )
+            .await
+            .map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    async fn keyboard_type(&self, text: &str) -> Result<(), EngineError> {
+        use chromiumoxide::cdp::browser_protocol::input::{
+            DispatchKeyEventParams, DispatchKeyEventType,
+        };
+        for ch in text.chars() {
+            self.page
+                .execute(
+                    DispatchKeyEventParams::builder()
+                        .r#type(DispatchKeyEventType::Char)
+                        .text(ch.to_string())
+                        .build()
+                        .map_err(EngineError::Browser)?,
+                )
+                .await
+                .map_err(to_engine_error)?;
+        }
+        Ok(())
+    }
+
+    async fn keyboard_down(&self, key: &str) -> Result<(), EngineError> {
+        use chromiumoxide::cdp::browser_protocol::input::{
+            DispatchKeyEventParams, DispatchKeyEventType,
+        };
+        self.page
+            .execute(
+                DispatchKeyEventParams::builder()
+                    .r#type(DispatchKeyEventType::KeyDown)
+                    .key(key.to_string())
+                    .build()
+                    .map_err(EngineError::Browser)?,
+            )
+            .await
+            .map_err(to_engine_error)?;
+        Ok(())
+    }
+
+    async fn keyboard_up(&self, key: &str) -> Result<(), EngineError> {
+        use chromiumoxide::cdp::browser_protocol::input::{
+            DispatchKeyEventParams, DispatchKeyEventType,
+        };
+        self.page
+            .execute(
+                DispatchKeyEventParams::builder()
+                    .r#type(DispatchKeyEventType::KeyUp)
+                    .key(key.to_string())
+                    .build()
+                    .map_err(EngineError::Browser)?,
+            )
+            .await
+            .map_err(to_engine_error)?;
+        Ok(())
+    }
+}
+
+/// Convert a CSS length (`"1in"`, `"2cm"`, `"10mm"`, `"72px"`) to inches for
+/// the CDP PDF API. Returns `None` on unknown/missing units.
+fn css_length_to_inches(value: Option<&str>) -> Option<f64> {
+    let raw = value?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let (num_str, unit) = raw
+        .find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+        .map(|idx| raw.split_at(idx))
+        .unwrap_or((raw, "in"));
+    let value: f64 = num_str.parse().ok()?;
+    Some(match unit.trim() {
+        "in" | "" => value,
+        "cm" => value / 2.54,
+        "mm" => value / 25.4,
+        "px" => value / 96.0,
+        "pt" => value / 72.0,
+        _ => return None,
+    })
+}
+
+/// Convert common paper format names into `(width, height)` in inches.
+fn paper_format_inches(name: &str) -> Option<(f64, f64)> {
+    let n = name.trim().to_ascii_lowercase();
+    Some(match n.as_str() {
+        "letter" => (8.5, 11.0),
+        "legal" => (8.5, 14.0),
+        "tabloid" => (11.0, 17.0),
+        "ledger" => (17.0, 11.0),
+        "a0" => (33.1, 46.8),
+        "a1" => (23.4, 33.1),
+        "a2" => (16.54, 23.4),
+        "a3" => (11.7, 16.54),
+        "a4" => (8.27, 11.69),
+        "a5" => (5.83, 8.27),
+        "a6" => (4.13, 5.83),
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn css_length_to_inches_handles_common_units() {
+        assert_eq!(css_length_to_inches(Some("1in")), Some(1.0));
+        assert_eq!(css_length_to_inches(Some("2.54cm")), Some(1.0));
+        assert_eq!(css_length_to_inches(Some("25.4mm")), Some(1.0));
+        assert_eq!(css_length_to_inches(Some("96px")), Some(1.0));
+        assert_eq!(css_length_to_inches(Some("72pt")), Some(1.0));
+    }
+
+    #[test]
+    fn css_length_to_inches_rejects_unknown_units() {
+        assert_eq!(css_length_to_inches(Some("10xx")), None);
+        assert_eq!(css_length_to_inches(None), None);
+        assert_eq!(css_length_to_inches(Some("")), None);
+    }
+
+    #[test]
+    fn css_length_to_inches_defaults_to_inches() {
+        // A bare number is treated as inches.
+        assert_eq!(css_length_to_inches(Some("1")), Some(1.0));
+    }
+
+    #[test]
+    fn paper_format_inches_known_formats() {
+        assert_eq!(paper_format_inches("A4"), Some((8.27, 11.69)));
+        assert_eq!(paper_format_inches("letter"), Some((8.5, 11.0)));
+        assert_eq!(paper_format_inches("Legal"), Some((8.5, 14.0)));
+    }
+
+    #[test]
+    fn paper_format_inches_unknown() {
+        assert!(paper_format_inches("weird").is_none());
+    }
+}

--- a/rust/src/browser/launcher.rs
+++ b/rust/src/browser/launcher.rs
@@ -3,10 +3,17 @@
 //! This module provides utilities for launching browser instances
 //! with appropriate configuration.
 
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chromiumoxide::browser::{Browser as CdpBrowser, BrowserConfig, HeadlessMode};
+use futures::StreamExt;
+
+use crate::browser::chromiumoxide_adapter::ChromiumoxidePage;
 use crate::browser::media::ColorScheme;
 use crate::core::constants::CHROME_ARGS;
-use crate::core::engine::EngineType;
-use std::path::PathBuf;
+use crate::core::engine::{EngineAdapter, EngineType};
 
 /// Options for launching a browser.
 #[derive(Debug, Clone)]
@@ -25,6 +32,15 @@ pub struct LaunchOptions {
     pub args: Vec<String>,
     /// Color scheme to emulate. `None` uses the system default.
     pub color_scheme: Option<ColorScheme>,
+    /// Optional timeout for the browser launch handshake.
+    pub launch_timeout: Option<Duration>,
+    /// Whether to run the browser with the Chromium sandbox enabled.
+    ///
+    /// Defaults to `true`. Disable when running in environments where the
+    /// sandbox is unavailable (e.g. CI containers without the required
+    /// capabilities). This translates to the `--no-sandbox` /
+    /// `--disable-setuid-sandbox` Chromium flags.
+    pub sandbox: bool,
 }
 
 impl Default for LaunchOptions {
@@ -37,6 +53,8 @@ impl Default for LaunchOptions {
             verbose: false,
             args: Vec::new(),
             color_scheme: None,
+            launch_timeout: None,
+            sandbox: true,
         }
     }
 }
@@ -94,6 +112,18 @@ impl LaunchOptions {
         self
     }
 
+    /// Override the browser launch timeout.
+    pub fn launch_timeout(mut self, timeout: Duration) -> Self {
+        self.launch_timeout = Some(timeout);
+        self
+    }
+
+    /// Enable or disable the Chromium sandbox for the launched browser.
+    pub fn sandbox(mut self, sandbox: bool) -> Self {
+        self.sandbox = sandbox;
+        self
+    }
+
     /// Get all Chrome arguments (default + custom).
     pub fn all_chrome_args(&self) -> Vec<String> {
         let mut all_args: Vec<String> = CHROME_ARGS.iter().map(|s| s.to_string()).collect();
@@ -113,11 +143,8 @@ impl LaunchOptions {
     }
 }
 
-/// Browser instance wrapper.
-///
-/// This is a placeholder struct that would wrap the actual browser
-/// instance from the underlying engine (chromiumoxide or fantoccini).
-#[derive(Debug)]
+/// Browser metadata returned alongside a launched page.
+#[derive(Debug, Clone)]
 pub struct Browser {
     /// The engine type being used.
     pub engine: EngineType,
@@ -128,16 +155,39 @@ pub struct Browser {
 }
 
 /// Result of a browser launch.
-#[derive(Debug)]
+///
+/// Contains both static metadata (`browser`) and a live
+/// [`EngineAdapter`] (`page`) that can be passed to the navigation,
+/// interaction, and query helpers exposed by this crate.
 pub struct LaunchResult {
-    /// The browser instance.
+    /// The browser metadata.
     pub browser: Browser,
+    /// A live page/adapter tied to the launched browser.
+    ///
+    /// For `Chromiumoxide`, this is a [`ChromiumoxidePage`](crate::browser::ChromiumoxidePage)
+    /// implementing [`EngineAdapter`]. Pass `launch_result.page.as_ref()` to
+    /// `goto`, `click`, `evaluate`, and other helpers.
+    pub page: Arc<dyn EngineAdapter>,
+}
+
+impl std::fmt::Debug for LaunchResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LaunchResult")
+            .field("browser", &self.browser)
+            .field("page", &"<dyn EngineAdapter>")
+            .finish()
+    }
 }
 
 /// Launch a browser with the given options.
 ///
-/// Note: This is a placeholder implementation. The actual implementation
-/// would use chromiumoxide or fantoccini to launch a real browser.
+/// For the `Chromiumoxide` engine, this starts a Chromium process, waits for
+/// the CDP handshake, opens a blank page, and returns a [`LaunchResult`]
+/// containing both the metadata (`browser`) and a live page adapter (`page`)
+/// implementing [`EngineAdapter`].
+///
+/// The `Fantoccini` engine is not yet implemented as a managed launcher; use
+/// chromiumoxide or connect to an externally-managed WebDriver session.
 ///
 /// # Arguments
 ///
@@ -145,33 +195,113 @@ pub struct LaunchResult {
 ///
 /// # Returns
 ///
-/// The launch result containing the browser instance
+/// The launch result containing the browser metadata and a page adapter
 ///
 /// # Errors
 ///
-/// Returns an error if the browser fails to launch
+/// Returns an error if the browser fails to launch.
 pub async fn launch_browser(options: LaunchOptions) -> Result<LaunchResult, anyhow::Error> {
     if options.verbose {
         tracing::info!("Launching browser with {} engine...", options.engine);
     }
 
     let user_data_dir = options.get_user_data_dir();
-
-    // Create user data directory if it doesn't exist
     std::fs::create_dir_all(&user_data_dir)?;
 
-    // This is a placeholder - actual implementation would launch real browser
-    let browser = Browser {
-        engine: options.engine,
-        user_data_dir,
-        headless: options.headless,
+    match options.engine {
+        EngineType::Chromiumoxide => launch_chromiumoxide(options, user_data_dir).await,
+        EngineType::Fantoccini => Err(anyhow::anyhow!(
+            "fantoccini engine launch is not yet implemented; \
+             connect to an existing WebDriver session or use EngineType::Chromiumoxide"
+        )),
+    }
+}
+
+async fn launch_chromiumoxide(
+    options: LaunchOptions,
+    user_data_dir: PathBuf,
+) -> Result<LaunchResult, anyhow::Error> {
+    let headless_mode = if options.headless {
+        HeadlessMode::New
+    } else {
+        HeadlessMode::False
     };
 
-    if options.verbose {
-        tracing::info!("Browser launched with {} engine", options.engine);
+    let mut builder = BrowserConfig::builder()
+        .user_data_dir(&user_data_dir)
+        .headless_mode(headless_mode)
+        .args(options.all_chrome_args());
+
+    if !options.sandbox {
+        builder = builder.no_sandbox();
     }
 
-    Ok(LaunchResult { browser })
+    if let Some(timeout) = options.launch_timeout {
+        builder = builder.launch_timeout(timeout);
+    }
+
+    let config = builder
+        .build()
+        .map_err(|e| anyhow::anyhow!("failed to build browser config: {}", e))?;
+
+    let (browser, mut handler) = CdpBrowser::launch(config)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to launch chromium: {}", e))?;
+
+    // Drain the CDP event stream on a background task. Dropping the handler
+    // causes the browser to hang, so we must keep polling it for the lifetime
+    // of the browser. Errors are logged but do not abort the task — the CDP
+    // channel naturally returns errors once the browser is closed.
+    let handler_task = tokio::spawn(async move {
+        while let Some(event) = handler.next().await {
+            if let Err(err) = event {
+                tracing::debug!(error = %err, "chromiumoxide handler event error");
+            }
+        }
+    });
+
+    let page = browser
+        .new_page("about:blank")
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to open initial page: {}", e))?;
+
+    let engine = options.engine;
+    let headless = options.headless;
+    let color_scheme = options.color_scheme.clone();
+
+    let adapter = ChromiumoxidePage::new(page, browser, handler_task, user_data_dir.clone());
+
+    // Apply color scheme emulation (best-effort).
+    if let Some(ref cs) = color_scheme {
+        if let Err(err) = adapter.set_color_scheme(Some(cs)).await {
+            if options.verbose {
+                tracing::warn!(error = %err, "could not set color scheme");
+            }
+        }
+    }
+
+    // Bring the page to front so the address bar is not focused when running
+    // headful — mirrors the JS launcher's behavior.
+    if !headless {
+        if let Err(err) = adapter.bring_to_front().await {
+            if options.verbose {
+                tracing::debug!(error = %err, "bring_to_front failed");
+            }
+        }
+    }
+
+    if options.verbose {
+        tracing::info!("Browser launched with {} engine", engine);
+    }
+
+    Ok(LaunchResult {
+        browser: Browser {
+            engine,
+            user_data_dir,
+            headless,
+        },
+        page: Arc::new(adapter),
+    })
 }
 
 #[cfg(test)]
@@ -238,5 +368,12 @@ mod tests {
         let dir = options.get_user_data_dir();
         assert!(dir.to_string_lossy().contains("browser-commander"));
         assert!(dir.to_string_lossy().contains("chromiumoxide-data"));
+    }
+
+    #[tokio::test]
+    async fn launch_fantoccini_is_unimplemented() {
+        let options = LaunchOptions::fantoccini();
+        let err = launch_browser(options).await.unwrap_err();
+        assert!(err.to_string().contains("fantoccini"));
     }
 }

--- a/rust/src/browser/mod.rs
+++ b/rust/src/browser/mod.rs
@@ -4,10 +4,12 @@
 //! - Launching browser instances
 //! - Navigation operations
 
+pub mod chromiumoxide_adapter;
 pub mod launcher;
 pub mod media;
 pub mod navigation_ops;
 
+pub use chromiumoxide_adapter::ChromiumoxidePage;
 pub use launcher::{launch_browser, Browser, LaunchOptions, LaunchResult};
 pub use media::{emulate_media, ColorScheme, EmulateMediaOptions};
 pub use navigation_ops::{

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,16 +14,19 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use browser_commander::browser::{LaunchOptions, launch_browser};
+//! use browser_commander::browser::{launch_browser, LaunchOptions};
 //!
 //! #[tokio::main]
 //! async fn main() -> anyhow::Result<()> {
 //!     // Launch a browser
-//!     let options = LaunchOptions::chromiumoxide()
-//!         .headless(true);
-//!
+//!     let options = LaunchOptions::chromiumoxide().headless(true);
 //!     let result = launch_browser(options).await?;
-//!     println!("Browser launched: {:?}", result.browser.engine);
+//!
+//!     // The returned `page` is an `Arc<dyn EngineAdapter>` and can be
+//!     // passed to any of the crate's navigation / interaction helpers.
+//!     let page = result.page.as_ref();
+//!     page.goto("https://example.com").await?;
+//!     println!("Current URL: {}", page.url().await?);
 //!
 //!     Ok(())
 //! }
@@ -47,8 +50,8 @@ pub mod utilities;
 
 // Re-export commonly used items at crate root
 pub use browser::{
-    emulate_media, launch_browser, Browser, ColorScheme, EmulateMediaOptions, LaunchOptions,
-    LaunchResult,
+    emulate_media, launch_browser, Browser, ChromiumoxidePage, ColorScheme, EmulateMediaOptions,
+    LaunchOptions, LaunchResult,
 };
 pub use core::{
     DialogEvent, DialogManager, DialogType, EngineAdapter, EngineError, EngineType, Logger,

--- a/rust/tests/launch_smoke.rs
+++ b/rust/tests/launch_smoke.rs
@@ -1,0 +1,76 @@
+//! Smoke test that launches a real Chromium via `launch_browser` and exercises
+//! the returned page adapter. Requires a working Chrome/Chromium installation
+//! and is therefore marked `#[ignore]`; run explicitly with:
+//!
+//! ```sh
+//! cargo test --test launch_smoke -- --ignored --nocapture
+//! ```
+
+use std::time::Duration;
+
+use browser_commander::{launch_browser, LaunchOptions};
+
+#[tokio::test]
+#[ignore]
+async fn launch_and_navigate() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let options = LaunchOptions::chromiumoxide()
+        .headless(true)
+        .sandbox(false)
+        .user_data_dir(tmp.path())
+        .with_args(vec!["--disable-dev-shm-usage".to_string()])
+        .launch_timeout(Duration::from_secs(20));
+
+    let result = launch_browser(options).await?;
+    let page = result.page.clone();
+
+    page.goto("data:text/html,<!doctype html><title>ok</title><h1 id=hi>hello</h1>")
+        .await?;
+
+    let url = page.url().await?;
+    assert!(url.starts_with("data:"), "unexpected url: {url}");
+
+    let content = page
+        .evaluate("document.querySelector('#hi').textContent")
+        .await?;
+    assert_eq!(content.as_str(), Some("hello"));
+
+    let visible = page.is_visible("#hi").await?;
+    assert!(visible);
+
+    let count = page.count("h1").await?;
+    assert_eq!(count, 1);
+
+    Ok(())
+}
+
+struct TempDir {
+    path: std::path::PathBuf,
+}
+
+impl TempDir {
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn tempdir() -> std::io::Result<TempDir> {
+    let base = std::env::temp_dir();
+    let unique = format!(
+        "bc-launch-smoke-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let path = base.join(unique);
+    std::fs::create_dir_all(&path)?;
+    Ok(TempDir { path })
+}


### PR DESCRIPTION
Fixes #49.

## Problem

`browser-commander` 0.9.1's Rust `launch_browser` was a placeholder — it
created a user data directory and returned metadata only (`LaunchResult { browser: Browser }`),
so the README quick start (`let page = &result.page; goto(page, ...)`)
did not compile and consumers had to drop down to `chromiumoxide`
directly.

## What changed

`launch_browser(options)` now:

- Builds a `chromiumoxide::BrowserConfig` from `LaunchOptions`
  (headless, sandbox, extra Chrome args, launch timeout, user data
  dir).
- Starts a Chromium process, completes the CDP handshake, and drains
  CDP events on a background Tokio task for the lifetime of the
  browser (the background task is aborted on `close()` / drop).
- Opens an initial `about:blank` page.
- Applies color-scheme emulation when requested.
- Brings the page to front (headful only), matching the JS launcher.

`LaunchResult` gains a `page: Arc<dyn EngineAdapter>` field, so
callers can now actually do:

```rust
let options = LaunchOptions::chromiumoxide().headless(true);
let result = launch_browser(options).await?;
let page = result.page.as_ref();

page.goto("https://example.com").await?;
page.click("button.submit").await?;
page.fill("input[name='email']", "test@example.com").await?;
```

## New module: `browser::chromiumoxide_adapter::ChromiumoxidePage`

Implements the full `EngineAdapter` trait on top of
`chromiumoxide::Page`, covering:

- Navigation: `goto`, `url`, `wait_for_navigation`
- Element queries: `query_selector`, `query_selector_all`, `count`,
  `text_content`, `input_value`, `get_attribute`, `is_visible`,
  `is_enabled`, `wait_for_selector`, `scroll_into_view`
- Interaction: `click`, `fill`, `type_text`
- Evaluation: `evaluate` (returns `serde_json::Value`)
- Media: `screenshot`, `pdf` (with CSS length + paper format parsing:
  `"1cm"`, `"0.5in"`, `"A4"`, `"Letter"`, …)
- Keyboard: `keyboard_press/type/down/up` via CDP
  `Input.dispatchKeyEvent`
- `bring_to_front`, color-scheme emulation

A `raw_page()` escape hatch is exposed for chromiumoxide-specific
APIs not yet covered by the unified trait.

## New `LaunchOptions` knobs

- `.sandbox(bool)` — toggles Chromium sandbox (useful for CI
  containers where the sandbox is unavailable).
- `.launch_timeout(Duration)` — override the CDP handshake timeout.

## Tests

- All 141 existing unit tests + 6 doctests still pass.
- New `tests/launch_smoke.rs` (marked `#[ignore]` so it only runs when
  explicitly requested) launches a real headless Chromium, navigates
  to a data URL, evaluates JavaScript, checks visibility, and counts
  elements. Verified locally with:

  ```
  cargo test --test launch_smoke -- --ignored
  ```

  → `test launch_and_navigate ... ok`

## Follow-ups (out of scope)

- `EngineType::Fantoccini` launch is still not implemented; the
  launcher returns an explicit error pointing users at
  `EngineType::Chromiumoxide` or an externally-managed WebDriver
  session.
- A few `EngineAdapter` helpers (`query_selector*`, `is_visible`) use
  JS shims rather than CDP DOM introspection, to keep this PR focused
  on the launch/page plumbing.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (unit + doctests)
- [x] `cargo test --test launch_smoke -- --ignored` (real Chromium)