### PR TITLE
Add system browser selection to launchBrowser

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-10T11:15:41.449Z for PR creation at branch issue-51-f2a446afa3b9 for issue https://github.com/link-foundation/browser-commander/issues/51
 # Updated: 2026-06-28T20:40:17.765Z
+# Updated: 2026-08-01T13:05:59.091Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-10T11:15:41.449Z for PR creation at branch issue-51-f2a446afa3b9 for issue https://github.com/link-foundation/browser-commander/issues/51
 # Updated: 2026-06-28T20:40:17.765Z
-# Updated: 2026-08-01T13:05:59.091Z

--- a/js/.changeset/system-browser-selection.md
+++ b/js/.changeset/system-browser-selection.md
@@ -1,0 +1,5 @@
+---
+'browser-commander': minor
+---
+
+Add `channel` and `executablePath` launch options for reusing an installed Chrome-family browser.

--- a/js/README.md
+++ b/js/README.md
@@ -87,6 +87,19 @@ await commander.destroy();
 await browser.close();
 ```
 
+To reuse an installed Chrome-family browser instead of downloading the
+engine's bundled Chromium, select a browser channel or provide its executable
+path. Both options are passed directly to Playwright or Puppeteer:
+
+```javascript
+const { browser, page } = await launchBrowser({
+  engine: 'playwright',
+  channel: 'chrome',
+  // Or: executablePath: '/usr/bin/google-chrome',
+  headless: true,
+});
+```
+
 ## Browser Commander Tests
 
 `browser-commander/tests` adds browser fixtures and scheduling helpers on top of

--- a/js/src/browser/launch-options.js
+++ b/js/src/browser/launch-options.js
@@ -1,0 +1,51 @@
+function setBrowserSelectionOptions(options, { channel, executablePath }) {
+  if (channel !== undefined) {
+    options.channel = channel;
+  }
+  if (executablePath !== undefined) {
+    options.executablePath = executablePath;
+  }
+  return options;
+}
+
+export function buildPlaywrightLaunchOptions({
+  headless,
+  slowMo,
+  chromeArgs,
+  colorScheme,
+  channel,
+  executablePath,
+}) {
+  const options = {
+    headless,
+    slowMo,
+    chromiumSandbox: true,
+    viewport: null,
+    args: chromeArgs,
+    ignoreDefaultArgs: ['--enable-automation'],
+  };
+
+  if (colorScheme !== undefined) {
+    options.colorScheme = colorScheme;
+  }
+
+  return setBrowserSelectionOptions(options, { channel, executablePath });
+}
+
+export function buildPuppeteerLaunchOptions({
+  headless,
+  chromeArgs,
+  userDataDir,
+  channel,
+  executablePath,
+}) {
+  return setBrowserSelectionOptions(
+    {
+      headless,
+      defaultViewport: null,
+      args: ['--start-maximized', ...chromeArgs],
+      userDataDir,
+    },
+    { channel, executablePath }
+  );
+}

--- a/js/src/browser/launcher.js
+++ b/js/src/browser/launcher.js
@@ -3,6 +3,10 @@ import os from 'os';
 import { CHROME_ARGS } from '../core/constants.js';
 import { disableTranslateInPreferences } from '../core/preferences.js';
 import { emulateMedia } from './media.js';
+import {
+  buildPlaywrightLaunchOptions,
+  buildPuppeteerLaunchOptions,
+} from './launch-options.js';
 
 /**
  * Launch browser with default configuration
@@ -14,6 +18,8 @@ import { emulateMedia } from './media.js';
  * @param {boolean} options.verbose - Enable verbose logging (default: false)
  * @param {string[]} options.args - Custom Chrome arguments to append to the default CHROME_ARGS
  * @param {string|null} [options.colorScheme] - Emulate color scheme: 'light', 'dark', 'no-preference', or null to reset
+ * @param {string} [options.channel] - Installed browser channel, such as 'chrome', 'chrome-beta', or 'msedge'
+ * @param {string} [options.executablePath] - Explicit path to a Chrome or Chromium executable
  * @returns {Promise<Object>} - Object with browser and page
  */
 export async function launchBrowser(options = {}) {
@@ -25,6 +31,8 @@ export async function launchBrowser(options = {}) {
     verbose = false,
     args = [],
     colorScheme,
+    channel,
+    executablePath,
   } = options;
 
   // Combine default CHROME_ARGS with custom args
@@ -53,18 +61,14 @@ export async function launchBrowser(options = {}) {
 
   if (engine === 'playwright') {
     const { chromium } = await import('playwright');
-    const contextOptions = {
+    const contextOptions = buildPlaywrightLaunchOptions({
       headless,
       slowMo,
-      chromiumSandbox: true,
-      viewport: null,
-      args: chromeArgs,
-      ignoreDefaultArgs: ['--enable-automation'],
-    };
-    // Playwright supports colorScheme as a context-level launch option
-    if (colorScheme !== undefined) {
-      contextOptions.colorScheme = colorScheme;
-    }
+      chromeArgs,
+      colorScheme,
+      channel,
+      executablePath,
+    });
     browser = await chromium.launchPersistentContext(
       userDataDir,
       contextOptions
@@ -72,12 +76,15 @@ export async function launchBrowser(options = {}) {
     page = browser.pages()[0];
   } else {
     const puppeteer = await import('puppeteer');
-    browser = await puppeteer.default.launch({
-      headless,
-      defaultViewport: null,
-      args: ['--start-maximized', ...chromeArgs],
-      userDataDir,
-    });
+    browser = await puppeteer.default.launch(
+      buildPuppeteerLaunchOptions({
+        headless,
+        chromeArgs,
+        userDataDir,
+        channel,
+        executablePath,
+      })
+    );
     const pages = await browser.pages();
     page = pages[0];
   }

--- a/js/tests/unit/browser/launch-options.test.js
+++ b/js/tests/unit/browser/launch-options.test.js
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  buildPlaywrightLaunchOptions,
+  buildPuppeteerLaunchOptions,
+} from '../../../src/browser/launch-options.js';
+
+describe('browser launch options', () => {
+  it('forwards channel and executablePath to Playwright', () => {
+    const options = buildPlaywrightLaunchOptions({
+      headless: true,
+      slowMo: 25,
+      chromeArgs: ['--custom'],
+      channel: 'chrome-beta',
+      executablePath: '/opt/google/chrome-beta',
+    });
+
+    assert.equal(options.channel, 'chrome-beta');
+    assert.equal(options.executablePath, '/opt/google/chrome-beta');
+  });
+
+  it('forwards channel and executablePath to Puppeteer', () => {
+    const options = buildPuppeteerLaunchOptions({
+      headless: true,
+      chromeArgs: ['--custom'],
+      userDataDir: '/tmp/browser-commander-test',
+      channel: 'chrome',
+      executablePath: '/usr/bin/google-chrome',
+    });
+
+    assert.equal(options.channel, 'chrome');
+    assert.equal(options.executablePath, '/usr/bin/google-chrome');
+  });
+
+  it('omits browser selection options by default', () => {
+    const playwright = buildPlaywrightLaunchOptions({
+      headless: false,
+      slowMo: 150,
+      chromeArgs: [],
+    });
+    const puppeteer = buildPuppeteerLaunchOptions({
+      headless: false,
+      chromeArgs: [],
+      userDataDir: '/tmp/browser-commander-test',
+    });
+
+    assert.equal('channel' in playwright, false);
+    assert.equal('executablePath' in playwright, false);
+    assert.equal('channel' in puppeteer, false);
+    assert.equal('executablePath' in puppeteer, false);
+  });
+});

--- a/rust/README.md
+++ b/rust/README.md
@@ -108,6 +108,21 @@ let puppeteer = LaunchOptions::puppeteer()
     .node_working_dir("./js");
 ```
 
+Reuse a system-installed Chrome-family browser by selecting its channel or
+providing an explicit executable path. `channel` applies to the Playwright and
+Puppeteer bridge engines; `executable_path` also applies to Chromiumoxide:
+
+```rust
+let playwright = LaunchOptions::playwright()
+    .channel("chrome")
+    .headless(true)
+    .node_working_dir("./js");
+
+let chromiumoxide = LaunchOptions::chromiumoxide()
+    .executable_path("/usr/bin/google-chrome")
+    .headless(true);
+```
+
 You can also set a custom Node executable:
 
 ```rust

--- a/rust/changelog.d/57.system-browser-selection.md
+++ b/rust/changelog.d/57.system-browser-selection.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+---
+
+### Added
+
+- Added `LaunchOptions::channel` and `LaunchOptions::executable_path` for reusing an installed Chrome-family browser.

--- a/rust/src/browser/launcher.rs
+++ b/rust/src/browser/launcher.rs
@@ -31,6 +31,10 @@ pub struct LaunchOptions {
     pub verbose: bool,
     /// Additional Chrome arguments.
     pub args: Vec<String>,
+    /// Installed browser channel for Playwright/Puppeteer (for example, `chrome`).
+    pub channel: Option<String>,
+    /// Explicit path to a Chrome or Chromium executable.
+    pub executable_path: Option<PathBuf>,
     /// Color scheme to emulate. `None` uses the system default.
     pub color_scheme: Option<ColorScheme>,
     /// Optional timeout for the browser launch handshake.
@@ -57,6 +61,8 @@ impl Default for LaunchOptions {
             slow_mo: 0,
             verbose: false,
             args: Vec::new(),
+            channel: None,
+            executable_path: None,
             color_scheme: None,
             launch_timeout: None,
             sandbox: true,
@@ -136,6 +142,18 @@ impl LaunchOptions {
     /// Add additional Chrome arguments.
     pub fn with_args(mut self, args: Vec<String>) -> Self {
         self.args = args;
+        self
+    }
+
+    /// Select an installed browser channel for Playwright or Puppeteer.
+    pub fn channel(mut self, channel: impl Into<String>) -> Self {
+        self.channel = Some(channel.into());
+        self
+    }
+
+    /// Select an explicit Chrome or Chromium executable.
+    pub fn executable_path(mut self, executable_path: impl Into<PathBuf>) -> Self {
+        self.executable_path = Some(executable_path.into());
         self
     }
 
@@ -308,6 +326,10 @@ async fn launch_chromiumoxide(
         builder = builder.no_sandbox();
     }
 
+    if let Some(ref executable_path) = options.executable_path {
+        builder = builder.chrome_executable(executable_path);
+    }
+
     if let Some(timeout) = options.launch_timeout {
         builder = builder.launch_timeout(timeout);
     }
@@ -388,6 +410,8 @@ mod tests {
         assert_eq!(options.slow_mo, 0);
         assert!(!options.verbose);
         assert!(options.args.is_empty());
+        assert!(options.channel.is_none());
+        assert!(options.executable_path.is_none());
         assert!(options.node_executable.is_none());
         assert!(options.node_working_dir.is_none());
     }
@@ -430,10 +454,17 @@ mod tests {
     fn launch_options_node_bridge_configuration() {
         let options = LaunchOptions::playwright()
             .node_executable("/custom/node")
-            .node_working_dir("/project/js");
+            .node_working_dir("/project/js")
+            .channel("chrome-beta")
+            .executable_path("/opt/google/chrome-beta");
 
         assert_eq!(options.node_executable, Some(PathBuf::from("/custom/node")));
         assert_eq!(options.node_working_dir, Some(PathBuf::from("/project/js")));
+        assert_eq!(options.channel.as_deref(), Some("chrome-beta"));
+        assert_eq!(
+            options.executable_path,
+            Some(PathBuf::from("/opt/google/chrome-beta"))
+        );
     }
 
     #[test]

--- a/rust/src/browser/node_bridge.rs
+++ b/rust/src/browser/node_bridge.rs
@@ -109,21 +109,9 @@ impl NodeBridgePage {
             stderr_task: Arc::new(Mutex::new(stderr_task)),
         };
 
-        page.request(
-            "launch",
-            json!({
-                "engine": engine.to_string(),
-                "userDataDir": path_to_string(&user_data_dir),
-                "headless": options.headless,
-                "slowMo": options.slow_mo,
-                "verbose": options.verbose,
-                "args": options.all_chrome_args(),
-                "colorScheme": options.color_scheme.as_ref().map(|cs| cs.as_str()),
-                "sandbox": options.sandbox,
-            }),
-        )
-        .await
-        .map_err(|err| anyhow::anyhow!("{}", err))?;
+        page.request("launch", launch_params(&options, &user_data_dir))
+            .await
+            .map_err(|err| anyhow::anyhow!("{}", err))?;
 
         Ok(page)
     }
@@ -217,6 +205,21 @@ impl NodeBridgePage {
         let value = self.request(method, params).await?;
         Ok(value.as_bool().unwrap_or(false))
     }
+}
+
+fn launch_params(options: &LaunchOptions, user_data_dir: &Path) -> Value {
+    json!({
+        "engine": options.engine.to_string(),
+        "userDataDir": path_to_string(user_data_dir),
+        "headless": options.headless,
+        "slowMo": options.slow_mo,
+        "verbose": options.verbose,
+        "args": options.all_chrome_args(),
+        "colorScheme": options.color_scheme.as_ref().map(|cs| cs.as_str()),
+        "sandbox": options.sandbox,
+        "channel": options.channel,
+        "executablePath": options.executable_path.as_deref().map(path_to_string),
+    })
 }
 
 impl std::fmt::Debug for NodeBridgePage {
@@ -467,4 +470,29 @@ fn element_info_from_value(value: &Value) -> Result<Option<ElementInfo>, EngineE
             .unwrap_or(true),
         bounding_box,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launch_params_forward_browser_selection() {
+        let options = LaunchOptions::playwright()
+            .channel("chrome-beta")
+            .executable_path("/opt/google/chrome-beta");
+
+        let params = launch_params(&options, Path::new("/tmp/browser-data"));
+
+        assert_eq!(params["channel"], "chrome-beta");
+        assert_eq!(params["executablePath"], "/opt/google/chrome-beta");
+    }
+
+    #[test]
+    fn launch_params_default_browser_selection_is_null() {
+        let params = launch_params(&LaunchOptions::puppeteer(), Path::new("/tmp/browser-data"));
+
+        assert!(params["channel"].is_null());
+        assert!(params["executablePath"].is_null());
+    }
 }

--- a/rust/src/browser/node_engine_bridge.js
+++ b/rust/src/browser/node_engine_bridge.js
@@ -101,6 +101,12 @@ async function launchPlaywright(params) {
   if (params.colorScheme !== null && params.colorScheme !== undefined) {
     contextOptions.colorScheme = params.colorScheme;
   }
+  if (params.channel !== null && params.channel !== undefined) {
+    contextOptions.channel = params.channel;
+  }
+  if (params.executablePath !== null && params.executablePath !== undefined) {
+    contextOptions.executablePath = params.executablePath;
+  }
 
   context = await chromium.launchPersistentContext(
     params.userDataDir,
@@ -113,13 +119,20 @@ async function launchPlaywright(params) {
 
 async function launchPuppeteer(params) {
   const puppeteer = await import("puppeteer");
-  browser = await puppeteer.default.launch({
+  const launchOptions = {
     headless: params.headless,
     slowMo: params.slowMo,
     defaultViewport: null,
     args: ["--start-maximized", ...chromeArgs(params)],
     userDataDir: params.userDataDir,
-  });
+  };
+  if (params.channel !== null && params.channel !== undefined) {
+    launchOptions.channel = params.channel;
+  }
+  if (params.executablePath !== null && params.executablePath !== undefined) {
+    launchOptions.executablePath = params.executablePath;
+  }
+  browser = await puppeteer.default.launch(launchOptions);
   const pages = await browser.pages();
   page = pages[0] ?? (await browser.newPage());
 


### PR DESCRIPTION
## Summary

- Add JavaScript `channel` and `executablePath` options to `launchBrowser()` and forward them verbatim to Playwright and Puppeteer.
- Add Rust `LaunchOptions::channel` and `LaunchOptions::executable_path` builders, including Node bridge forwarding and native Chromiumoxide executable selection.
- Document system-browser usage and add minor-release metadata for both packages.

## Reproduction

Before this change, neither JavaScript's `launchBrowser()` option destructuring nor Rust's `LaunchOptions` contained a browser channel or executable path. Supplying either value was therefore ignored, and the engines fell back to their bundled/detected Chromium.

The new regression tests build the launch options for both engines and assert that supplied values survive unchanged, while default calls omit browser-selection options. Rust tests also verify builder defaults and the JSON sent through the Node bridge.

## Verification

- `npm test` — 461 passed
- `npm run check`
- `npm run docs:api`
- `npm run changeset:status`
- `node scripts/validate-changeset.mjs` with the PR base/head SHAs
- `cargo test --all-features --verbose`
- `cargo test --doc --verbose`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `node rust/scripts/check-file-size.mjs`
- `cargo doc --no-deps --all-features`
- Runtime smoke test with installed `/usr/bin/google-chrome`: Playwright via `channel: 'chrome'` and Puppeteer via `executablePath` both launched and closed successfully.

Note: the first full JavaScript run hit a transient Node 20 test-runner deserialization error in an unrelated `fill.test.js` worker. That file passed independently, and the complete rerun passed all 461 tests.

Fixes #57
