### PR TITLE
Add managed setContent for in-memory HTML

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-10T11:15:41.449Z for PR creation at branch issue-51-f2a446afa3b9 for issue https://github.com/link-foundation/browser-commander/issues/51
 # Updated: 2026-06-28T20:40:17.765Z
+# Updated: 2026-08-01T16:08:23.376Z

--- a/js/.changeset/managed-set-content.md
+++ b/js/.changeset/managed-set-content.md
@@ -1,0 +1,5 @@
+---
+'browser-commander': minor
+---
+
+Add `commander.setContent()` for safely loading in-memory HTML through the managed navigation lifecycle.

--- a/js/README.md
+++ b/js/README.md
@@ -82,6 +82,12 @@ commander.pageTrigger({
 // 4. Navigate - action auto-starts when page is ready
 await commander.goto({ url: 'https://example.com' });
 
+// Or safely replace the document with in-memory HTML
+await commander.setContent({
+  html: '<h1>Hi</h1>',
+  waitUntil: 'networkidle',
+});
+
 // 5. Cleanup
 await commander.destroy();
 await browser.close();

--- a/js/examples/pdf-generation.js
+++ b/js/examples/pdf-generation.js
@@ -1,8 +1,8 @@
 /**
  * Example: PDF generation via browser-commander
  *
- * This example shows how to use the unified page.pdf() method
- * instead of the old workaround: `const rawPage = page._page || page`.
+ * This example shows how to load in-memory HTML and generate a PDF through the
+ * unified commander API.
  *
  * Supports both Playwright and Puppeteer engines.
  *
@@ -45,8 +45,11 @@ async function generatePdf() {
   try {
     const commander = makeBrowserCommander({ page, verbose: false });
 
-    // Navigate to a page
-    await page.goto('https://example.com');
+    // Load HTML assembled in memory using the managed navigation lifecycle.
+    await commander.setContent({
+      html: '<main><h1>Browser Commander</h1><p>Generated in memory.</p></main>',
+      waitUntil: 'load',
+    });
 
     // Generate PDF using the unified API (no workarounds needed!)
     const pdfBuffer = await commander.pdf({

--- a/js/src/README.md
+++ b/js/src/README.md
@@ -417,6 +417,19 @@ await commander.goto({
 });
 ```
 
+### commander.setContent(options)
+
+Load an in-memory HTML document while preserving the same page-trigger cleanup
+and readiness guarantees as `goto()`:
+
+```javascript
+await commander.setContent({
+  html: '<h1>Hi</h1>',
+  waitUntil: 'networkidle', // Playwright/Puppeteer option
+  timeout: 60000,
+});
+```
+
 ### commander.clickButton(options)
 
 ```javascript

--- a/js/src/bindings.js
+++ b/js/src/bindings.js
@@ -8,6 +8,7 @@ import { getUrl, unfocusAddressBar } from './utilities/url.js';
 import {
   waitForUrlStabilization,
   goto,
+  setContent,
   waitForNavigation,
   waitForPageReady,
   waitAfterAction,
@@ -105,6 +106,12 @@ export function createBoundFunctions(options = {}) {
       ...opts,
       page,
       waitForUrlStabilization: waitForUrlStabilizationBound,
+      navigationManager,
+    });
+  const setContentBound = (opts) =>
+    setContent({
+      ...opts,
+      page,
       navigationManager,
     });
   const waitForNavigationBound = (opts) =>
@@ -294,6 +301,7 @@ export function createBoundFunctions(options = {}) {
     querySelectorAll: querySelectorAllBound,
     waitForUrlStabilization: waitForUrlStabilizationBound,
     goto: gotoBound,
+    setContent: setContentBound,
     getUrl: getUrlBound,
     waitForNavigation: waitForNavigationBound,
     waitForPageReady: waitForPageReadyBound,

--- a/js/src/browser/navigation.js
+++ b/js/src/browser/navigation.js
@@ -349,6 +349,64 @@ export async function goto(options = {}) {
 }
 
 /**
+ * Replace the current document with an in-memory HTML string.
+ * When NavigationManager is available, this uses the same managed lifecycle as
+ * goto so active page triggers are stopped before the document is replaced.
+ *
+ * @param {Object} options - Configuration options
+ * @param {Object} options.page - Browser page object
+ * @param {Object} options.navigationManager - NavigationManager instance (preferred)
+ * @param {string} options.html - HTML to load
+ * @param {string} options.waitUntil - Wait until condition (default: 'load')
+ * @param {number} options.timeout - Content loading timeout in ms (default: 60000)
+ * @returns {Promise<Object>} Content loading result
+ */
+export async function setContent(options = {}) {
+  const {
+    page,
+    navigationManager,
+    html,
+    waitUntil = 'load',
+    timeout = 60000,
+  } = options;
+
+  if (typeof html !== 'string') {
+    throw new Error('html is required in options');
+  }
+
+  try {
+    let loaded;
+    if (navigationManager) {
+      loaded = await navigationManager.setContent({
+        html,
+        waitUntil,
+        timeout,
+      });
+    } else {
+      await page.setContent(html, { waitUntil, timeout });
+      loaded = true;
+    }
+
+    return loaded
+      ? { loaded: true, actualUrl: page.url() }
+      : {
+          loaded: false,
+          actualUrl: page.url(),
+          reason: 'content loading stopped/interrupted',
+        };
+  } catch (error) {
+    if (isNavigationError(error) || isActionStoppedError(error)) {
+      return {
+        loaded: false,
+        actualUrl: page.url(),
+        reason: 'content loading stopped/interrupted',
+      };
+    }
+    throw error;
+  }
+}
+
+/**
  * Wait for navigation
  * @param {Object} options - Configuration options
  * @param {Object} options.page - Browser page object

--- a/js/src/core/navigation-manager.js
+++ b/js/src/core/navigation-manager.js
@@ -11,6 +11,47 @@
 import { isNavigationError } from './navigation-safety.js';
 import { TIMING } from './constants.js';
 
+async function setManagedContent(options = {}) {
+  const {
+    page,
+    log,
+    html,
+    waitUntil = 'load',
+    timeout = 60000,
+    currentUrl,
+    triggerNavigationStart,
+    updateCurrentUrl,
+    waitForPageReady,
+    completeNavigation,
+  } = options;
+
+  if (typeof html !== 'string') {
+    throw new Error('html is required in options');
+  }
+
+  log.debug(() => '🚀 Loading in-memory HTML content');
+
+  try {
+    // Treat document replacement as a controlled navigation so active page
+    // triggers stop before the old document is discarded.
+    await triggerNavigationStart({ url: currentUrl, isExternal: false });
+    await page.setContent(html, { waitUntil, timeout });
+
+    // setContent normally preserves the URL, but inline scripts can navigate.
+    updateCurrentUrl();
+    await waitForPageReady({ timeout, reason: 'after setContent' });
+    return true;
+  } catch (error) {
+    // Do not leave the manager in its loading state when setContent fails.
+    completeNavigation();
+    if (isNavigationError(error)) {
+      log.debug(() => '⚠️  Content loading was interrupted, recovering...');
+      return false;
+    }
+    throw error;
+  }
+}
+
 /**
  * Create a NavigationManager instance for a page
  * @param {Object} options - Configuration options
@@ -341,6 +382,18 @@ export function createNavigationManager(options = {}) {
     }
   }
 
+  const setContent = (opts = {}) =>
+    setManagedContent({
+      page,
+      log,
+      ...opts,
+      currentUrl,
+      triggerNavigationStart,
+      updateCurrentUrl: () => (currentUrl = page.url()),
+      waitForPageReady,
+      completeNavigation,
+    });
+
   /**
    * Wait for any pending navigation to complete
    * @param {Object} options - Configuration options
@@ -371,27 +424,6 @@ export function createNavigationManager(options = {}) {
     }
 
     return await navigationPromise;
-  }
-
-  /**
-   * Check if we're currently navigating
-   */
-  function isCurrentlyNavigating() {
-    return isNavigating;
-  }
-
-  /**
-   * Get current URL
-   */
-  function getCurrentUrl() {
-    return currentUrl;
-  }
-
-  /**
-   * Get current session ID
-   */
-  function getSessionId() {
-    return sessionId;
   }
 
   /**
@@ -476,13 +508,14 @@ export function createNavigationManager(options = {}) {
   return {
     // Navigation
     navigate,
+    setContent,
     waitForNavigation,
     waitForPageReady,
 
     // State
-    isNavigating: isCurrentlyNavigating,
-    getCurrentUrl,
-    getSessionId,
+    isNavigating: () => isNavigating,
+    getCurrentUrl: () => currentUrl,
+    getSessionId: () => sessionId,
 
     // Abort handling - use these to stop operations when navigation occurs
     getAbortSignal,

--- a/js/src/exports.js
+++ b/js/src/exports.js
@@ -47,6 +47,7 @@ export { emulateMedia } from './browser/media.js';
 export {
   waitForUrlStabilization,
   goto,
+  setContent,
   waitForNavigation,
   waitForPageReady,
   waitAfterAction,

--- a/js/tests/e2e/playwright.e2e.test.js
+++ b/js/tests/e2e/playwright.e2e.test.js
@@ -522,5 +522,24 @@ describe(
         // Test passes if no error is thrown
       });
     });
+
+    describe('In-memory Content', () => {
+      it('should load HTML through commander.setContent', async () => {
+        if (!commander) {
+          return;
+        }
+
+        const result = await commander.setContent({
+          html: '<main><h1 data-testid="content-title">In memory</h1></main>',
+          waitUntil: 'load',
+        });
+        const title = await commander.textContent({
+          selector: '[data-testid="content-title"]',
+        });
+
+        assert.strictEqual(result.loaded, true);
+        assert.strictEqual(title, 'In memory');
+      });
+    });
   }
 );

--- a/js/tests/e2e/puppeteer.e2e.test.js
+++ b/js/tests/e2e/puppeteer.e2e.test.js
@@ -476,4 +476,23 @@ describe('E2E Tests - Puppeteer Engine', { skip: !process.env.RUN_E2E }, () => {
       assert.strictEqual(modalClosed, false);
     });
   });
+
+  describe('In-memory Content', () => {
+    it('should load HTML through commander.setContent', async () => {
+      if (!commander) {
+        return;
+      }
+
+      const result = await commander.setContent({
+        html: '<main><h1 data-testid="content-title">In memory</h1></main>',
+        waitUntil: 'load',
+      });
+      const title = await commander.textContent({
+        selector: '[data-testid="content-title"]',
+      });
+
+      assert.strictEqual(result.loaded, true);
+      assert.strictEqual(title, 'In memory');
+    });
+  });
 });

--- a/js/tests/helpers/mocks.js
+++ b/js/tests/helpers/mocks.js
@@ -88,6 +88,7 @@ export function createMockPlaywrightPage(options = {}) {
     _isPlaywrightPage: true,
     url: () => url,
     goto: async (targetUrl, opts = {}) => {},
+    setContent: async (html, opts = {}) => {},
     waitForNavigation: async (opts = {}) => {},
     waitForSelector: async (sel, opts = {}) => locatorMock(sel),
     $: async (sel) => locatorMock(sel),
@@ -193,6 +194,7 @@ export function createMockPuppeteerPage(options = {}) {
     _isPuppeteerPage: true,
     url: () => url,
     goto: async (targetUrl, opts = {}) => {},
+    setContent: async (html, opts = {}) => {},
     waitForNavigation: async (opts = {}) => {},
     waitForSelector: async (sel, opts = {}) => elementMock(sel),
     $: async (sel) => {
@@ -434,6 +436,7 @@ export function createMockNavigationManager(options = {}) {
       url = opts.url || url;
       return true;
     },
+    setContent: async (opts = {}) => true,
     waitForNavigation: async (opts = {}) => true,
     waitForPageReady: async (opts = {}) => true,
     isNavigating: () => navigating,

--- a/js/tests/unit/bindings.test.js
+++ b/js/tests/unit/bindings.test.js
@@ -62,6 +62,10 @@ describe('bindings', () => {
         'goto should be a function'
       );
       assert.ok(
+        typeof bindings.setContent === 'function',
+        'setContent should be a function'
+      );
+      assert.ok(
         typeof bindings.getUrl === 'function',
         'getUrl should be a function'
       );

--- a/js/tests/unit/browser/navigation.test.js
+++ b/js/tests/unit/browser/navigation.test.js
@@ -5,6 +5,7 @@ import {
   verifyNavigation,
   waitForUrlStabilization,
   goto,
+  setContent,
   waitForNavigation,
   waitForPageReady,
   waitAfterAction,
@@ -200,6 +201,66 @@ describe('navigation', () => {
 
       assert.strictEqual(gotoCalled, true);
       assert.strictEqual(result.navigated, true);
+    });
+  });
+
+  describe('setContent', () => {
+    it('should throw when html is not provided', async () => {
+      const page = createMockPlaywrightPage();
+
+      await assert.rejects(() => setContent({ page }), /html is required/);
+    });
+
+    it('should load content using navigationManager', async () => {
+      const page = createMockPlaywrightPage();
+      const navigationManager = createMockNavigationManager();
+      let receivedOptions;
+      navigationManager.setContent = async (options) => {
+        receivedOptions = options;
+        return true;
+      };
+
+      const result = await setContent({
+        page,
+        navigationManager,
+        html: '<h1>Hi</h1>',
+        waitUntil: 'networkidle',
+        timeout: 5000,
+      });
+
+      assert.deepStrictEqual(receivedOptions, {
+        html: '<h1>Hi</h1>',
+        waitUntil: 'networkidle',
+        timeout: 5000,
+      });
+      assert.deepStrictEqual(result, {
+        loaded: true,
+        actualUrl: 'https://example.com',
+      });
+    });
+
+    it('should load content directly without navigationManager', async () => {
+      const page = createMockPlaywrightPage();
+      let receivedArguments;
+      page.setContent = async (...args) => {
+        receivedArguments = args;
+      };
+
+      const result = await setContent({
+        page,
+        html: '',
+        waitUntil: 'load',
+        timeout: 5000,
+      });
+
+      assert.deepStrictEqual(receivedArguments, [
+        '',
+        { waitUntil: 'load', timeout: 5000 },
+      ]);
+      assert.deepStrictEqual(result, {
+        loaded: true,
+        actualUrl: 'https://example.com',
+      });
     });
   });
 

--- a/js/tests/unit/core/navigation-manager.test.js
+++ b/js/tests/unit/core/navigation-manager.test.js
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createNavigationManager } from '../../../src/core/navigation-manager.js';
+import {
+  createMockPlaywrightPage,
+  createMockLogger,
+} from '../../helpers/mocks.js';
+
+describe('navigation manager', () => {
+  describe('setContent', () => {
+    it('should apply the full managed navigation lifecycle', async () => {
+      const page = createMockPlaywrightPage();
+      const log = createMockLogger();
+      const calls = [];
+      page.setContent = async (...args) => calls.push(['setContent', ...args]);
+
+      const manager = createNavigationManager({
+        page,
+        engine: 'playwright',
+        log,
+      });
+      manager.configure({ redirectStabilizationTime: 0 });
+      manager.onSessionCleanup(() => calls.push(['cleanup']));
+      manager.on('onNavigationStart', () => calls.push(['navigationStart']));
+      manager.on('onPageReady', () => calls.push(['pageReady']));
+
+      const loaded = await manager.setContent({
+        html: '<h1>Hi</h1>',
+        waitUntil: 'networkidle',
+        timeout: 5000,
+      });
+
+      assert.strictEqual(loaded, true);
+      assert.strictEqual(manager.getSessionId(), 1);
+      assert.strictEqual(manager.isNavigating(), false);
+      assert.deepStrictEqual(calls, [
+        ['cleanup'],
+        ['navigationStart'],
+        [
+          'setContent',
+          '<h1>Hi</h1>',
+          { waitUntil: 'networkidle', timeout: 5000 },
+        ],
+        ['pageReady'],
+      ]);
+    });
+
+    it('should require html while accepting an empty string', async () => {
+      const page = createMockPlaywrightPage();
+      const log = createMockLogger();
+      const manager = createNavigationManager({
+        page,
+        engine: 'playwright',
+        log,
+      });
+      manager.configure({ redirectStabilizationTime: 0 });
+
+      await assert.rejects(() => manager.setContent(), /html is required/);
+      await assert.doesNotReject(() => manager.setContent({ html: '' }));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `commander.setContent({ html, waitUntil, timeout })` for loading in-memory HTML with Playwright and Puppeteer.
- Route managed content replacement through the same trigger cleanup, session, navigation, and page-readiness lifecycle used by `goto()`.
- Export and bind the functional API, document the new flow, and update the PDF example to render HTML assembled in memory.
- Add a minor changeset plus unit and real-engine regression coverage.

## Reproduction

Before this change, `commander.setContent` did not exist. Calling `page.setContent()` directly replaced the document without notifying `NavigationManager`, so an active page-trigger action was not aborted and cleaned up before its DOM disappeared.

The regression tests now assert that a managed content load runs cleanup and navigation-start callbacks before `page.setContent`, advances the session, waits for page readiness, and returns to the working state. They also verify option forwarding, the navigation-manager-disabled fallback, and valid empty HTML.

## Verification

- `npm run check`
- `npm test` — 478 passed
- `npm run docs:api`
- `node scripts/validate-changeset.mjs` with PR base/head SHAs
- Focused Playwright E2E against a real Chromium — passed
- Focused Puppeteer E2E against installed Google Chrome — passed (one known transient Node 20 test-runner deserialization failure, immediate rerun passed)

A full Playwright E2E run also executed and passed the new in-memory-content test. The overall legacy suite remained red because an existing Escape-key test leaves its modal open and causes subsequent modal-click timeouts; this is unrelated to `setContent`.

Fixes #60
