### PR TITLE
Add portable browser storage state support

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-10T11:15:41.449Z for PR creation at branch issue-51-f2a446afa3b9 for issue https://github.com/link-foundation/browser-commander/issues/51
 # Updated: 2026-06-28T20:40:17.765Z
-# Updated: 2026-08-01T16:19:19.170Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-10T11:15:41.449Z for PR creation at branch issue-51-f2a446afa3b9 for issue https://github.com/link-foundation/browser-commander/issues/51
 # Updated: 2026-06-28T20:40:17.765Z
+# Updated: 2026-08-01T16:19:19.170Z

--- a/docs/feature-parity.md
+++ b/docs/feature-parity.md
@@ -18,6 +18,7 @@ This matrix tracks the shared API surface across the maintained language impleme
 | --------------------------------------- | --------------------- | -------------------- | ------------------ | ---------------------- | --------------------- |
 | Launch browser                          | Supported             | Supported            | Supported          | Supported              | Supported             |
 | Persistent user data directory          | Supported             | Supported            | Supported          | Supported              | Supported             |
+| Portable cookie/localStorage state      | Supported             | Supported            | Not implemented    | Not implemented        | Not implemented       |
 | Custom Chrome args                      | Supported             | Supported            | Supported          | Supported              | Supported             |
 | Headless launch                         | Supported             | Supported            | Supported          | Supported              | Supported             |
 | Color scheme at launch                  | Supported             | Supported            | Supported          | Supported              | Supported             |

--- a/experiments/storage-state-smoke.mjs
+++ b/experiments/storage-state-smoke.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { launchBrowser, saveStorageState } from "../js/src/index.js";
+
+const [engine, browserExecutable] = process.argv.slice(2);
+if (!["playwright", "puppeteer"].includes(engine) || !browserExecutable) {
+  throw new Error(
+    "Usage: node experiments/storage-state-smoke.mjs <playwright|puppeteer> <browser-executable>",
+  );
+}
+
+const temporaryDirectory = await mkdtemp(
+  path.join(os.tmpdir(), `browser-commander-${engine}-storage-state-`),
+);
+const firstProfile = path.join(temporaryDirectory, "first-profile");
+const secondProfile = path.join(temporaryDirectory, "second-profile");
+let firstBrowser;
+let secondBrowser;
+
+try {
+  const first = await launchBrowser({
+    engine,
+    executablePath: browserExecutable,
+    userDataDir: firstProfile,
+    headless: true,
+  });
+  firstBrowser = first.browser;
+  await first.page.goto("https://example.com");
+  await first.page.evaluate(() =>
+    globalThis.localStorage.setItem("theme", "dark"),
+  );
+  if (engine === "playwright") {
+    await first.page
+      .context()
+      .addCookies([
+        { name: "session", value: "saved", url: "https://example.com" },
+      ]);
+  } else {
+    await first.page.setCookie({
+      name: "session",
+      value: "saved",
+      url: "https://example.com",
+    });
+  }
+  const storageState = await saveStorageState(first.page);
+  await firstBrowser.close();
+  firstBrowser = undefined;
+
+  const second = await launchBrowser({
+    engine,
+    executablePath: browserExecutable,
+    userDataDir: secondProfile,
+    headless: true,
+    storageState,
+  });
+  secondBrowser = second.browser;
+  await second.page.goto("https://example.com");
+
+  assert.equal(
+    await second.page.evaluate(() => globalThis.localStorage.getItem("theme")),
+    "dark",
+  );
+  assert.match(
+    await second.page.evaluate(() => document.cookie),
+    /session=saved/,
+  );
+  console.log(`${engine} storage-state smoke test passed`);
+} finally {
+  await firstBrowser?.close();
+  await secondBrowser?.close();
+  await rm(temporaryDirectory, { recursive: true, force: true });
+}

--- a/experiments/storage-state-smoke.mjs
+++ b/experiments/storage-state-smoke.mjs
@@ -17,6 +17,7 @@ const temporaryDirectory = await mkdtemp(
 );
 const firstProfile = path.join(temporaryDirectory, "first-profile");
 const secondProfile = path.join(temporaryDirectory, "second-profile");
+const storageStatePath = path.join(temporaryDirectory, "storage-state.json");
 let firstBrowser;
 let secondBrowser;
 
@@ -45,7 +46,7 @@ try {
       url: "https://example.com",
     });
   }
-  const storageState = await saveStorageState(first.page);
+  await saveStorageState(first.page, storageStatePath);
   await firstBrowser.close();
   firstBrowser = undefined;
 
@@ -54,7 +55,7 @@ try {
     executablePath: browserExecutable,
     userDataDir: secondProfile,
     headless: true,
-    storageState,
+    storageState: storageStatePath,
   });
   secondBrowser = second.browser;
   await second.page.goto("https://example.com");

--- a/js/.changeset/portable-storage-state.md
+++ b/js/.changeset/portable-storage-state.md
@@ -1,0 +1,5 @@
+---
+'browser-commander': minor
+---
+
+Add portable cookie and localStorage restoration through `launchBrowser({ storageState })` and the `saveStorageState()` helper for Playwright and Puppeteer.

--- a/js/README.md
+++ b/js/README.md
@@ -100,6 +100,22 @@ const { browser, page } = await launchBrowser({
 });
 ```
 
+Reuse a saved authenticated session by passing Playwright-compatible storage
+state as a JSON file path or object. Cookies and localStorage are restored for
+both engines:
+
+```javascript
+import { launchBrowser, saveStorageState } from 'browser-commander';
+
+const { browser, page } = await launchBrowser({
+  engine: 'playwright',
+  storageState: './gmail-state.json',
+});
+
+// Save the current session for a later launch.
+await saveStorageState(page, './gmail-state.json');
+```
+
 ## Browser Commander Tests
 
 `browser-commander/tests` adds browser fixtures and scheduling helpers on top of
@@ -271,10 +287,25 @@ const { browser, page } = await launchBrowser({
   slowMo: 150, // Slow down operations (ms)
   verbose: false, // Enable debug logging
   args: ['--no-sandbox', '--disable-setuid-sandbox'], // Custom Chrome args to append
+  storageState: './session-state.json', // Saved cookies and localStorage, as a path or object
 });
 ```
 
 The `args` option allows passing custom Chrome arguments, which is useful for headless server environments (Docker, CI/CD) that require flags like `--no-sandbox`.
+
+The `storageState` option accepts a Playwright-compatible JSON path or object.
+Each engine restores its cookies and origin-specific localStorage before
+navigation, including when Playwright uses a persistent context.
+
+### saveStorageState(page, filePath)
+
+Save the current cookies and localStorage in Playwright's portable storage
+state format. The helper supports pages from either engine and also returns the
+saved object:
+
+```javascript
+const state = await saveStorageState(page, './session-state.json');
+```
 
 The `colorScheme` option allows setting the initial color scheme (`'light'`, `'dark'`, or `'no-preference'`) at launch time for screenshot services and testing tools:
 

--- a/js/src/browser/launcher.js
+++ b/js/src/browser/launcher.js
@@ -7,6 +7,11 @@ import {
   buildPlaywrightLaunchOptions,
   buildPuppeteerLaunchOptions,
 } from './launch-options.js';
+import {
+  loadStorageState,
+  restorePlaywrightStorageState,
+  restorePuppeteerStorageState,
+} from './storage-state.js';
 
 /**
  * Launch browser with default configuration
@@ -20,6 +25,7 @@ import {
  * @param {string|null} [options.colorScheme] - Emulate color scheme: 'light', 'dark', 'no-preference', or null to reset
  * @param {string} [options.channel] - Installed browser channel, such as 'chrome', 'chrome-beta', or 'msedge'
  * @param {string} [options.executablePath] - Explicit path to a Chrome or Chromium executable
+ * @param {string|Object} [options.storageState] - Playwright-compatible storage state path or object
  * @returns {Promise<Object>} - Object with browser and page
  */
 export async function launchBrowser(options = {}) {
@@ -33,6 +39,7 @@ export async function launchBrowser(options = {}) {
     colorScheme,
     channel,
     executablePath,
+    storageState,
   } = options;
 
   // Combine default CHROME_ARGS with custom args
@@ -43,6 +50,8 @@ export async function launchBrowser(options = {}) {
       `Invalid engine: ${engine}. Expected 'playwright' or 'puppeteer'`
     );
   }
+
+  const resolvedStorageState = await loadStorageState(storageState);
 
   // Set environment variables to suppress warnings
   process.env.GOOGLE_API_KEY = 'no';
@@ -74,6 +83,10 @@ export async function launchBrowser(options = {}) {
       contextOptions
     );
     page = browser.pages()[0];
+    await restorePlaywrightStorageState({
+      context: browser,
+      storageState: resolvedStorageState,
+    });
   } else {
     const puppeteer = await import('puppeteer');
     browser = await puppeteer.default.launch(
@@ -87,6 +100,10 @@ export async function launchBrowser(options = {}) {
     );
     const pages = await browser.pages();
     page = pages[0];
+    await restorePuppeteerStorageState({
+      page,
+      storageState: resolvedStorageState,
+    });
   }
 
   if (verbose) {

--- a/js/src/browser/storage-state.js
+++ b/js/src/browser/storage-state.js
@@ -1,0 +1,133 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+/**
+ * Load a Playwright-compatible storage state from a JSON path or object.
+ * @param {string|Object|undefined} storageState - State path or parsed state
+ * @returns {Promise<Object|undefined>} Parsed state
+ */
+export async function loadStorageState(storageState) {
+  if (storageState === undefined) {
+    return undefined;
+  }
+  if (typeof storageState === 'string') {
+    return JSON.parse(await readFile(storageState, 'utf8'));
+  }
+  if (storageState && typeof storageState === 'object') {
+    return storageState;
+  }
+  throw new TypeError('storageState must be a file path or an object');
+}
+
+function restoreOriginLocalStorage(origins) {
+  const originState = origins.find(
+    ({ origin }) => origin === globalThis.location.origin
+  );
+  if (!originState) {
+    return;
+  }
+  for (const { name, value } of originState.localStorage ?? []) {
+    globalThis.localStorage.setItem(name, value);
+  }
+}
+
+/**
+ * Apply Playwright-compatible storage state to a Puppeteer page.
+ * @param {Object} options - Restore options
+ * @param {Object} options.page - Puppeteer page
+ * @param {Object|undefined} options.storageState - Parsed storage state
+ * @returns {Promise<void>}
+ */
+export async function restorePuppeteerStorageState({ page, storageState }) {
+  if (!storageState) {
+    return;
+  }
+
+  const cookies = storageState.cookies ?? [];
+  if (cookies.length > 0) {
+    await page.setCookie(...cookies);
+  }
+
+  const origins = storageState.origins ?? [];
+  if (origins.length > 0) {
+    await page.evaluateOnNewDocument(restoreOriginLocalStorage, origins);
+    await page.evaluate(restoreOriginLocalStorage, origins);
+  }
+}
+
+/**
+ * Apply storage state to a Playwright persistent browser context.
+ * @param {Object} options - Restore options
+ * @param {Object} options.context - Playwright browser context
+ * @param {Object|undefined} options.storageState - Parsed storage state
+ * @returns {Promise<void>}
+ */
+export async function restorePlaywrightStorageState({ context, storageState }) {
+  if (!storageState) {
+    return;
+  }
+
+  const cookies = storageState.cookies ?? [];
+  if (cookies.length > 0) {
+    await context.addCookies(cookies);
+  }
+
+  const origins = storageState.origins ?? [];
+  if (origins.length > 0) {
+    await context.addInitScript(restoreOriginLocalStorage, origins);
+    await Promise.all(
+      context
+        .pages()
+        .map((page) => page.evaluate(restoreOriginLocalStorage, origins))
+    );
+  }
+}
+
+function readCurrentLocalStorage() {
+  return Array.from({ length: globalThis.localStorage.length }, (_, index) => {
+    const name = globalThis.localStorage.key(index);
+    return { name, value: globalThis.localStorage.getItem(name) };
+  });
+}
+
+async function collectPuppeteerStorageState(page) {
+  const cookies = await page.cookies();
+  const pageUrl = page.url();
+  const origin = new URL(pageUrl).origin;
+  const origins = [];
+
+  if (origin !== 'null') {
+    origins.push({
+      origin,
+      localStorage: await page.evaluate(readCurrentLocalStorage),
+    });
+  }
+
+  return { cookies, origins };
+}
+
+/**
+ * Save a page's cookies and localStorage in Playwright's storage-state format.
+ * @param {Object} page - Playwright or Puppeteer page
+ * @param {string} [filePath] - Optional JSON output path
+ * @returns {Promise<Object>} Saved storage state
+ */
+export async function saveStorageState(page, filePath) {
+  const context = typeof page.context === 'function' ? page.context() : null;
+  if (typeof context?.storageState === 'function') {
+    return context.storageState(filePath ? { path: filePath } : undefined);
+  }
+
+  if (
+    typeof page.cookies !== 'function' ||
+    typeof page.evaluate !== 'function' ||
+    typeof page.url !== 'function'
+  ) {
+    throw new TypeError('page must be a Playwright or Puppeteer page');
+  }
+
+  const storageState = await collectPuppeteerStorageState(page);
+  if (filePath) {
+    await writeFile(filePath, `${JSON.stringify(storageState, null, 2)}\n`);
+  }
+  return storageState;
+}

--- a/js/src/exports.js
+++ b/js/src/exports.js
@@ -43,6 +43,7 @@ export {
 
 // Re-export browser management
 export { launchBrowser } from './browser/launcher.js';
+export { saveStorageState } from './browser/storage-state.js';
 export { emulateMedia } from './browser/media.js';
 export {
   waitForUrlStabilization,

--- a/js/tests/unit/browser/storage-state.test.js
+++ b/js/tests/unit/browser/storage-state.test.js
@@ -1,0 +1,148 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  loadStorageState,
+  restorePlaywrightStorageState,
+  restorePuppeteerStorageState,
+  saveStorageState,
+} from '../../../src/browser/storage-state.js';
+import { saveStorageState as publicSaveStorageState } from '../../../src/index.js';
+
+describe('browser storage state', () => {
+  let temporaryDirectory;
+
+  afterEach(async () => {
+    if (temporaryDirectory) {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+      temporaryDirectory = undefined;
+    }
+  });
+
+  it('loads storage state from a path and accepts an object unchanged', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(os.tmpdir(), 'browser-commander-storage-state-')
+    );
+    const filePath = path.join(temporaryDirectory, 'state.json');
+    const state = {
+      cookies: [{ name: 'session', value: 'saved', domain: '.example.com' }],
+      origins: [],
+    };
+    await writeFile(filePath, JSON.stringify(state));
+
+    assert.deepEqual(await loadStorageState(filePath), state);
+    assert.equal(await loadStorageState(state), state);
+  });
+
+  it('rejects invalid storage state input', async () => {
+    await assert.rejects(
+      () => loadStorageState(null),
+      /storageState must be a file path or an object/
+    );
+  });
+
+  it('exports saveStorageState from the package API', () => {
+    assert.equal(publicSaveStorageState, saveStorageState);
+  });
+
+  it('restores Puppeteer cookies and localStorage before navigation', async () => {
+    const calls = [];
+    const state = {
+      cookies: [{ name: 'session', value: 'saved', domain: '.example.com' }],
+      origins: [
+        {
+          origin: 'https://example.com',
+          localStorage: [{ name: 'theme', value: 'dark' }],
+        },
+      ],
+    };
+    const page = {
+      setCookie: async (...cookies) => calls.push(['cookies', cookies]),
+      evaluateOnNewDocument: async (fn, value) =>
+        calls.push(['new-document', fn, value]),
+      evaluate: async (fn, value) => calls.push(['current-page', fn, value]),
+    };
+
+    await restorePuppeteerStorageState({ page, storageState: state });
+
+    assert.deepEqual(calls[0], ['cookies', state.cookies]);
+    assert.equal(calls[1][0], 'new-document');
+    assert.equal(calls[1][2], state.origins);
+    assert.equal(calls[2][0], 'current-page');
+    assert.equal(calls[2][2], state.origins);
+  });
+
+  it('restores Playwright cookies and localStorage before navigation', async () => {
+    const calls = [];
+    const state = {
+      cookies: [{ name: 'session', value: 'saved', domain: '.example.com' }],
+      origins: [
+        {
+          origin: 'https://example.com',
+          localStorage: [{ name: 'theme', value: 'dark' }],
+        },
+      ],
+    };
+    const page = {
+      evaluate: async (fn, value) => calls.push(['current-page', fn, value]),
+    };
+    const context = {
+      addCookies: async (cookies) => calls.push(['cookies', cookies]),
+      addInitScript: async (fn, value) =>
+        calls.push(['new-document', fn, value]),
+      pages: () => [page],
+    };
+
+    await restorePlaywrightStorageState({ context, storageState: state });
+
+    assert.deepEqual(calls[0], ['cookies', state.cookies]);
+    assert.equal(calls[1][0], 'new-document');
+    assert.equal(calls[1][2], state.origins);
+    assert.equal(calls[2][0], 'current-page');
+    assert.equal(calls[2][2], state.origins);
+  });
+
+  it('delegates Playwright saves to the page context', async () => {
+    const savedState = { cookies: [], origins: [] };
+    const calls = [];
+    const page = {
+      context: () => ({
+        storageState: async (options) => {
+          calls.push(options);
+          return savedState;
+        },
+      }),
+    };
+
+    assert.equal(await saveStorageState(page, '/tmp/state.json'), savedState);
+    assert.deepEqual(calls, [{ path: '/tmp/state.json' }]);
+  });
+
+  it('saves Puppeteer cookies and current-origin localStorage', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(os.tmpdir(), 'browser-commander-storage-state-')
+    );
+    const filePath = path.join(temporaryDirectory, 'state.json');
+    const cookies = [
+      { name: 'session', value: 'saved', domain: '.example.com' },
+    ];
+    const localStorage = [{ name: 'theme', value: 'dark' }];
+    const page = {
+      browserContext: () => ({}),
+      cookies: async () => cookies,
+      url: () => 'https://example.com/inbox',
+      evaluate: async () => localStorage,
+    };
+
+    const state = await saveStorageState(page, filePath);
+
+    assert.deepEqual(state, {
+      cookies,
+      origins: [{ origin: 'https://example.com', localStorage }],
+    });
+    assert.deepEqual(JSON.parse(await readFile(filePath, 'utf8')), state);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `storageState` path/object support to `launchBrowser()` for Playwright and Puppeteer.
- Restore cookies and origin-specific localStorage before navigation, including Playwright persistent contexts.
- Export `saveStorageState(page, filePath)` with Playwright-native saving and Playwright-compatible Puppeteer output.
- Document the API, update feature parity, and add a minor changeset.

## Reproduction

Before this change, `launchBrowser()` discarded the `storageState` option and the package exposed no helper for saving a session. A saved authenticated state therefore could not be injected through the unified API.

The regression suite loads both path and object forms, verifies each engine adapter receives cookies and localStorage, checks both save implementations, validates invalid input, and confirms the helper is publicly exported.

## Verification

- `npm test` — 468 passed
- `npm run check`
- `npm run docs:api`
- `npm run changeset:status`
- Real Chrome round trip with Playwright: save to a JSON path, relaunch with a clean profile, restore cookie and localStorage
- Real Chrome round trip with Puppeteer: save to a JSON path, relaunch with a clean profile, restore cookie and localStorage

No screenshots are included because this changes session initialization behavior rather than rendered UI.

Fixes #58