### PR TITLE
Add automation-friendly browser launch defaults

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-10T11:15:41.449Z for PR creation at branch issue-51-f2a446afa3b9 for issue https://github.com/link-foundation/browser-commander/issues/51
 # Updated: 2026-06-28T20:40:17.765Z
 # Updated: 2026-08-01T16:08:23.376Z
-# Updated: 2026-08-02T05:52:15.912Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-10T11:15:41.449Z for PR creation at branch issue-51-f2a446afa3b9 for issue https://github.com/link-foundation/browser-commander/issues/51
 # Updated: 2026-06-28T20:40:17.765Z
 # Updated: 2026-08-01T16:08:23.376Z
+# Updated: 2026-08-02T05:52:15.912Z

--- a/docs/feature-parity.md
+++ b/docs/feature-parity.md
@@ -55,6 +55,41 @@ This matrix tracks the shared API surface across the maintained language impleme
 | Seed cookies after connection           | Supported             | Supported                            | Supported               |
 | Return browser and page handles         | Raw engine handles    | Shared `EngineAdapter`               | Raw engine handles      |
 
+## Automation-Friendly Launch Defaults
+
+`launchBrowser()`/`launch_browser()` and the real-browser launch helpers add
+the following Chromium-family arguments unless the caller opts out. The
+defaults are the same on Linux, macOS, and Windows and apply when launching
+Chrome, Edge, Brave, or Chromium:
+
+| Default argument                   | Why it is applied                                                                                                    |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `--password-store=basic`           | Uses the isolated profile's built-in password backend instead of opening an OS Keychain/libsecret credential dialog. |
+| `--no-first-run`                   | Skips the first-run setup flow that can cover or redirect the first page.                                            |
+| `--no-default-browser-check`       | Prevents a default-browser prompt from interrupting automation.                                                      |
+| `--disable-infobars`               | Suppresses browser information bars that can obstruct page UI.                                                       |
+| `--disable-session-crashed-bubble` | Prevents a killed automation session from offering to restore tabs.                                                  |
+| `--hide-crash-restore-bubble`      | Hides the crash-restore surface on browser variants that honor this switch.                                          |
+| `--disable-crash-restore`          | Prevents stale tabs from being restored into the isolated profile.                                                   |
+
+The real-browser helpers additionally manage
+`--remote-debugging-address=127.0.0.1`, `--remote-debugging-port=<port>`, and
+`--user-data-dir=<dedicated profile>`. These three arguments cannot be
+overridden or ignored: CDP stays on loopback, and Chrome 136+ refuses remote
+debugging on its default profile. Headless mode is opt-in and emits
+`--headless=new`.
+
+Use `extraArgs` and `ignoreDefaultArgs` in JavaScript, `extra_args` and
+`ignore_default_args` in Python, or the corresponding Rust builder methods to
+append arguments or omit individual Browser Commander defaults. Existing
+`args`/`with_args()` calls remain supported. Opting out of
+`--password-store=basic` can restore operating-system credential prompts.
+
+`connectBrowser()`/`connect_browser()` only attaches to an existing process;
+it cannot change that process's command line. Start an externally managed
+browser with the defaults above and a dedicated remote-debugging profile, or
+use the real-browser launch helper to have Browser Commander apply them.
+
 ## Compatibility Notes
 
 - Existing Rust aliases remain compatible: `chromiumoxide` and `cdp` parse as `EngineType::Chromiumoxide`; `fantoccini` and `webdriver` parse as `EngineType::Fantoccini`.

--- a/js/.changeset/safe-browser-launch-defaults.md
+++ b/js/.changeset/safe-browser-launch-defaults.md
@@ -1,0 +1,5 @@
+---
+'browser-commander': minor
+---
+
+Apply automation-friendly Chromium launch defaults, including `--password-store=basic`, and add append/opt-out launch argument controls.

--- a/js/README.md
+++ b/js/README.md
@@ -103,8 +103,16 @@ const { browser, page } = await launchBrowser({
   channel: 'chrome',
   // Or: executablePath: '/usr/bin/google-chrome',
   headless: true,
+  extraArgs: ['--lang=en-US'],
+  // Per-flag escape hatch; `args` remains a compatible append-only alias.
+  ignoreDefaultArgs: ['--disable-infobars'],
 });
 ```
+
+Browser Commander applies the documented
+[automation-friendly launch defaults](../docs/feature-parity.md#automation-friendly-launch-defaults),
+including `--password-store=basic` to avoid an additional OS credential
+dialog. `ignoreDefaultArgs: true` omits every Browser Commander default.
 
 Attach to a Chrome-family browser that is already listening for CDP connections:
 
@@ -117,6 +125,10 @@ const { browser, page } = await connectBrowser({
 });
 const commander = makeBrowserCommander({ page });
 ```
+
+Attachment cannot change the existing process's launch arguments. Start it
+with a loopback remote-debugging port, a dedicated `--user-data-dir`, and the
+automation-friendly defaults above, or use `launchRealBrowser()`.
 
 `launchRealBrowser()` can find and start a genuine installed Chrome,
 Edge, Brave, or Chromium with a loopback CDP endpoint and then attach to it. It
@@ -131,6 +143,8 @@ const connection = await launchRealBrowser({
   engine: 'puppeteer',
   channel: 'chrome',
   userDataDir: '/tmp/my-automation-profile',
+  extraArgs: ['--lang=en-US'],
+  ignoreDefaultArgs: ['--disable-infobars'],
   seedCookies: [
     { name: 'session', value: 'saved', url: 'https://example.com' },
   ],
@@ -141,6 +155,8 @@ await connection.browser.close();
 Cookie seeding copies only cookies you explicitly provide; the helper does not
 read, decrypt, or expose cookies from a browser's default profile.
 `launchAndConnectRealBrowser()` remains available as a descriptive alias.
+Remote-debugging, loopback, and profile arguments remain managed even when all
+optional defaults are ignored; `headless: true` adds `--headless=new`.
 
 Reuse a saved authenticated session by passing Playwright-compatible storage
 state as a JSON file path or object. Cookies and localStorage are restored for
@@ -371,6 +387,9 @@ default browser-profile paths, protects its remote-debugging arguments, and
 returns the spawned `browserProcess`, resolved `cdpEndpoint`, executable path,
 and profile path alongside `{ browser, page }`.
 `launchAndConnectRealBrowser()` is an alias with identical behavior.
+`extraArgs` appends custom switches, while `ignoreDefaultArgs` accepts a list
+of defaults to omit (or `true` to omit all optional defaults). The older
+`args` append option remains supported.
 
 ### saveStorageState(page, filePath)
 

--- a/js/src/browser/launch-options.js
+++ b/js/src/browser/launch-options.js
@@ -1,3 +1,47 @@
+import { CHROME_ARGS } from '../core/constants.js';
+
+function stringArray(value, name) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new TypeError(`${name} must be an array of strings`);
+  }
+  return value;
+}
+
+/** Resolve Browser Commander defaults, compatibility args, and extra args. */
+export function resolveChromeArgs({
+  args = [],
+  extraArgs = [],
+  ignoreDefaultArgs = [],
+} = {}) {
+  stringArray(args, 'args');
+  stringArray(extraArgs, 'extraArgs');
+  if (
+    typeof ignoreDefaultArgs !== 'boolean' &&
+    !Array.isArray(ignoreDefaultArgs)
+  ) {
+    throw new TypeError('ignoreDefaultArgs must be a boolean or string array');
+  }
+  if (Array.isArray(ignoreDefaultArgs)) {
+    stringArray(ignoreDefaultArgs, 'ignoreDefaultArgs');
+  }
+
+  const normalizedIgnoreDefaultArgs =
+    ignoreDefaultArgs === false ? [] : ignoreDefaultArgs;
+  const ignored = new Set(
+    normalizedIgnoreDefaultArgs === true
+      ? CHROME_ARGS
+      : normalizedIgnoreDefaultArgs
+  );
+  return {
+    args: [
+      ...CHROME_ARGS.filter((argument) => !ignored.has(argument)),
+      ...args,
+      ...extraArgs,
+    ],
+    ignoreDefaultArgs: normalizedIgnoreDefaultArgs,
+  };
+}
+
 function setBrowserSelectionOptions(options, { channel, executablePath }) {
   if (channel !== undefined) {
     options.channel = channel;
@@ -15,14 +59,21 @@ export function buildPlaywrightLaunchOptions({
   colorScheme,
   channel,
   executablePath,
+  ignoreDefaultArgs = [],
 }) {
+  const normalizedIgnoreDefaultArgs =
+    ignoreDefaultArgs === false ? [] : ignoreDefaultArgs;
+  const engineIgnoreDefaultArgs =
+    normalizedIgnoreDefaultArgs === true
+      ? true
+      : [...new Set(['--enable-automation', ...normalizedIgnoreDefaultArgs])];
   const options = {
     headless,
     slowMo,
     chromiumSandbox: true,
     viewport: null,
     args: chromeArgs,
-    ignoreDefaultArgs: ['--enable-automation'],
+    ignoreDefaultArgs: engineIgnoreDefaultArgs,
   };
 
   if (colorScheme !== undefined) {
@@ -38,14 +89,21 @@ export function buildPuppeteerLaunchOptions({
   userDataDir,
   channel,
   executablePath,
+  ignoreDefaultArgs = [],
 }) {
-  return setBrowserSelectionOptions(
-    {
-      headless,
-      defaultViewport: null,
-      args: ['--start-maximized', ...chromeArgs],
-      userDataDir,
-    },
-    { channel, executablePath }
-  );
+  const normalizedIgnoreDefaultArgs =
+    ignoreDefaultArgs === false ? [] : ignoreDefaultArgs;
+  const options = {
+    headless,
+    defaultViewport: null,
+    args: ['--start-maximized', ...chromeArgs],
+    userDataDir,
+  };
+  if (
+    normalizedIgnoreDefaultArgs === true ||
+    normalizedIgnoreDefaultArgs.length > 0
+  ) {
+    options.ignoreDefaultArgs = normalizedIgnoreDefaultArgs;
+  }
+  return setBrowserSelectionOptions(options, { channel, executablePath });
 }

--- a/js/src/browser/launcher.js
+++ b/js/src/browser/launcher.js
@@ -1,11 +1,11 @@
 import path from 'path';
 import os from 'os';
-import { CHROME_ARGS } from '../core/constants.js';
 import { disableTranslateInPreferences } from '../core/preferences.js';
 import { emulateMedia } from './media.js';
 import {
   buildPlaywrightLaunchOptions,
   buildPuppeteerLaunchOptions,
+  resolveChromeArgs,
 } from './launch-options.js';
 import {
   loadStorageState,
@@ -22,6 +22,8 @@ import {
  * @param {number} options.slowMo - Slow down operations by ms (default: 150 for Playwright, 0 for Puppeteer)
  * @param {boolean} options.verbose - Enable verbose logging (default: false)
  * @param {string[]} options.args - Custom Chrome arguments to append to the default CHROME_ARGS
+ * @param {string[]} [options.extraArgs] - Additional Chrome arguments appended after legacy args
+ * @param {boolean|string[]} [options.ignoreDefaultArgs] - Browser Commander defaults to omit, or true for all
  * @param {string|null} [options.colorScheme] - Emulate color scheme: 'light', 'dark', 'no-preference', or null to reset
  * @param {string} [options.channel] - Installed browser channel, such as 'chrome', 'chrome-beta', or 'msedge'
  * @param {string} [options.executablePath] - Explicit path to a Chrome or Chromium executable
@@ -36,14 +38,20 @@ export async function launchBrowser(options = {}) {
     slowMo = engine === 'playwright' ? 150 : 0,
     verbose = false,
     args = [],
+    extraArgs = [],
+    ignoreDefaultArgs = [],
     colorScheme,
     channel,
     executablePath,
     storageState,
   } = options;
 
-  // Combine default CHROME_ARGS with custom args
-  const chromeArgs = [...CHROME_ARGS, ...args];
+  const resolvedChromeArgs = resolveChromeArgs({
+    args,
+    extraArgs,
+    ignoreDefaultArgs,
+  });
+  const chromeArgs = resolvedChromeArgs.args;
 
   if (!['playwright', 'puppeteer'].includes(engine)) {
     throw new Error(
@@ -77,6 +85,7 @@ export async function launchBrowser(options = {}) {
       colorScheme,
       channel,
       executablePath,
+      ignoreDefaultArgs: resolvedChromeArgs.ignoreDefaultArgs,
     });
     browser = await chromium.launchPersistentContext(
       userDataDir,
@@ -96,6 +105,7 @@ export async function launchBrowser(options = {}) {
         userDataDir,
         channel,
         executablePath,
+        ignoreDefaultArgs: resolvedChromeArgs.ignoreDefaultArgs,
       })
     );
     const pages = await browser.pages();

--- a/js/src/browser/real-browser.js
+++ b/js/src/browser/real-browser.js
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { connectBrowser } from './connector.js';
+import { resolveChromeArgs } from './launch-options.js';
 
 const MANAGED_ARGUMENTS = [
   '--remote-debugging-address',
@@ -240,6 +241,8 @@ export function buildRealBrowserArgs({
   remoteDebuggingPort = 0,
   headless = false,
   args = [],
+  extraArgs = [],
+  ignoreDefaultArgs = [],
 }) {
   if (
     !Number.isInteger(remoteDebuggingPort) ||
@@ -250,7 +253,8 @@ export function buildRealBrowserArgs({
       'remoteDebuggingPort must be an integer from 0 to 65535'
     );
   }
-  const conflictingArgument = args.find((argument) =>
+  const customArgs = [...args, ...extraArgs];
+  const conflictingArgument = customArgs.find((argument) =>
     MANAGED_ARGUMENTS.some(
       (managed) => argument === managed || argument.startsWith(`${managed}=`)
     )
@@ -261,14 +265,15 @@ export function buildRealBrowserArgs({
     );
   }
 
+  const defaultArgs = resolveChromeArgs({ ignoreDefaultArgs }).args;
+
   return [
     '--remote-debugging-address=127.0.0.1',
     `--remote-debugging-port=${remoteDebuggingPort}`,
     `--user-data-dir=${userDataDir}`,
-    '--no-first-run',
-    '--no-default-browser-check',
+    ...defaultArgs,
     ...(headless ? ['--headless=new'] : []),
-    ...args,
+    ...customArgs,
   ];
 }
 
@@ -353,6 +358,8 @@ export async function waitForCdpEndpoint({
  * @param {number} [options.remoteDebuggingPort=0] - Loopback CDP port; zero lets Chrome choose
  * @param {boolean} [options.headless=false] - Run the installed browser headlessly
  * @param {string[]} [options.args] - Additional browser arguments
+ * @param {string[]} [options.extraArgs] - Additional browser arguments appended after legacy args
+ * @param {boolean|string[]} [options.ignoreDefaultArgs] - Browser Commander defaults to omit, or true for all
  * @param {number} [options.startupTimeout=30000] - CDP readiness timeout in milliseconds
  * @param {Object[]} [options.seedCookies] - Cookies to seed after connecting
  * @param {boolean} [options.verbose=false] - Show browser and connection logs
@@ -384,6 +391,8 @@ export async function launchAndConnectRealBrowserWithDependencies(
     remoteDebuggingPort = 0,
     headless = false,
     args = [],
+    extraArgs = [],
+    ignoreDefaultArgs = [],
     startupTimeout = 30_000,
     verbose = false,
     cdpEndpoint,
@@ -409,6 +418,8 @@ export async function launchAndConnectRealBrowserWithDependencies(
     remoteDebuggingPort,
     headless,
     args,
+    extraArgs,
+    ignoreDefaultArgs,
   });
   const spawnBrowser = dependencies.spawnBrowser ?? spawn;
   const browserProcess = spawnBrowser(resolvedExecutablePath, browserArgs, {

--- a/js/src/core/constants.js
+++ b/js/src/core/constants.js
@@ -5,6 +5,7 @@ export const CHROME_ARGS = [
   '--disable-session-crashed-bubble',
   '--hide-crash-restore-bubble',
   '--disable-infobars',
+  '--password-store=basic',
   '--no-first-run',
   '--no-default-browser-check',
   '--disable-crash-restore',

--- a/js/tests/unit/browser/launch-options.test.js
+++ b/js/tests/unit/browser/launch-options.test.js
@@ -4,9 +4,55 @@ import assert from 'node:assert';
 import {
   buildPlaywrightLaunchOptions,
   buildPuppeteerLaunchOptions,
+  resolveChromeArgs,
 } from '../../../src/browser/launch-options.js';
 
 describe('browser launch options', () => {
+  it('applies safe defaults, appends extra arguments, and supports per-flag opt-out', () => {
+    const options = resolveChromeArgs({
+      args: ['--legacy-arg'],
+      extraArgs: ['--lang=en-US'],
+      ignoreDefaultArgs: ['--no-default-browser-check'],
+    });
+
+    assert.ok(options.args.includes('--password-store=basic'));
+    assert.ok(options.args.includes('--no-first-run'));
+    assert.equal(options.args.includes('--no-default-browser-check'), false);
+    assert.deepEqual(options.args.slice(-2), ['--legacy-arg', '--lang=en-US']);
+    assert.deepEqual(options.ignoreDefaultArgs, ['--no-default-browser-check']);
+  });
+
+  it('can ignore every Browser Commander default', () => {
+    const options = resolveChromeArgs({
+      extraArgs: ['--lang=en-US'],
+      ignoreDefaultArgs: true,
+    });
+
+    assert.deepEqual(options.args, ['--lang=en-US']);
+    assert.equal(options.ignoreDefaultArgs, true);
+  });
+
+  it('forwards ignored defaults to both browser engines', () => {
+    const playwright = buildPlaywrightLaunchOptions({
+      headless: false,
+      slowMo: 150,
+      chromeArgs: [],
+      ignoreDefaultArgs: ['--no-first-run'],
+    });
+    const puppeteer = buildPuppeteerLaunchOptions({
+      headless: false,
+      chromeArgs: [],
+      userDataDir: '/tmp/browser-commander-test',
+      ignoreDefaultArgs: ['--no-first-run'],
+    });
+
+    assert.deepEqual(playwright.ignoreDefaultArgs, [
+      '--enable-automation',
+      '--no-first-run',
+    ]);
+    assert.deepEqual(puppeteer.ignoreDefaultArgs, ['--no-first-run']);
+  });
+
   it('forwards channel and executablePath to Playwright', () => {
     const options = buildPlaywrightLaunchOptions({
       headless: true,

--- a/js/tests/unit/browser/launch-options.test.js
+++ b/js/tests/unit/browser/launch-options.test.js
@@ -32,6 +32,15 @@ describe('browser launch options', () => {
     assert.equal(options.ignoreDefaultArgs, true);
   });
 
+  it('can opt out of the password-store default specifically', () => {
+    const options = resolveChromeArgs({
+      ignoreDefaultArgs: ['--password-store=basic'],
+    });
+
+    assert.equal(options.args.includes('--password-store=basic'), false);
+    assert.ok(options.args.includes('--no-first-run'));
+  });
+
   it('forwards ignored defaults to both browser engines', () => {
     const playwright = buildPlaywrightLaunchOptions({
       headless: false,

--- a/js/tests/unit/browser/real-browser.test.js
+++ b/js/tests/unit/browser/real-browser.test.js
@@ -44,11 +44,30 @@ describe('launchAndConnectRealBrowser', () => {
       '--remote-debugging-address=127.0.0.1',
       '--remote-debugging-port=9333',
       '--user-data-dir=/tmp/browser-commander-dedicated',
+      '--disable-session-crashed-bubble',
+      '--hide-crash-restore-bubble',
+      '--disable-infobars',
+      '--password-store=basic',
       '--no-first-run',
       '--no-default-browser-check',
+      '--disable-crash-restore',
       '--headless=new',
       '--lang=en-US',
     ]);
+  });
+
+  it('supports additive arguments and per-default opt-out', () => {
+    const args = buildRealBrowserArgs({
+      userDataDir: '/tmp/browser-commander-dedicated',
+      args: ['--legacy-arg'],
+      extraArgs: ['--lang=en-US'],
+      ignoreDefaultArgs: ['--no-first-run'],
+    });
+
+    assert.ok(args.includes('--password-store=basic'));
+    assert.equal(args.includes('--no-first-run'), false);
+    assert.ok(args.includes('--no-default-browser-check'));
+    assert.deepEqual(args.slice(-2), ['--legacy-arg', '--lang=en-US']);
   });
 
   it('rejects custom arguments that could bypass protected CDP settings', () => {

--- a/js/tests/unit/core/constants.test.js
+++ b/js/tests/unit/core/constants.test.js
@@ -10,6 +10,7 @@ describe('constants', () => {
 
     it('should contain expected browser arguments', () => {
       assert.ok(CHROME_ARGS.includes('--disable-infobars'));
+      assert.ok(CHROME_ARGS.includes('--password-store=basic'));
       assert.ok(CHROME_ARGS.includes('--no-first-run'));
       assert.ok(CHROME_ARGS.includes('--no-default-browser-check'));
     });

--- a/python/README.md
+++ b/python/README.md
@@ -145,10 +145,17 @@ options = LaunchOptions(
     slow_mo=150,  # Slow down operations (ms)
     verbose=False,  # Enable debug logging
     args=["--no-sandbox"],  # Custom Chrome args
+    extra_args=["--lang=en-US"],  # Appended after legacy args
+    ignore_default_args=["--disable-infobars"],  # Per-default opt-out
 )
 result = await launch_browser(options)
 browser, page = result.browser, result.page
 ```
+
+Both launch APIs apply the documented
+[automation-friendly defaults](../docs/feature-parity.md#automation-friendly-launch-defaults),
+including `--password-store=basic` to avoid an extra OS credential dialog.
+Set `ignore_default_args=True` to omit every optional default.
 
 ### connect_browser(options)
 
@@ -175,6 +182,9 @@ The returned page is the raw engine page/driver and can be passed directly to
 non-default `--user-data-dir`; remote debugging is intentionally disabled for
 the default Chrome profile. Cookie seeding uses only values supplied by the
 caller and does not read the default profile.
+Because connection is attach-only, it cannot retrofit launch flags. Start the
+external process with the documented defaults and a dedicated debugging
+profile, or use `launch_real_browser()`.
 
 ### launch_real_browser(options)
 
@@ -190,6 +200,8 @@ result = await launch_real_browser(
         engine="playwright",  # or "selenium"
         channel="chrome",  # chrome, msedge, brave, or chromium
         user_data_dir="/tmp/browser-commander-profile",
+        extra_args=["--lang=en-US"],
+        ignore_default_args=["--disable-infobars"],
         seed_cookies=[
             {"name": "session", "value": "saved", "url": "https://example.com"}
         ],
@@ -205,6 +217,9 @@ The helper also supports beta/dev/canary channels and an explicit
 custom arguments from overriding its loopback address, debugging port, or
 profile. The returned `browser_process` can be terminated explicitly after
 closing the browser. `launch_and_connect_real_browser()` is an alias.
+The remote-debugging address, port, and profile remain managed; headless mode
+is opt-in and uses `--headless=new`. The older `args` field remains an
+append-only compatibility alias.
 
 The `color_scheme` option emulates `prefers-color-scheme` at launch time:
 

--- a/python/changelog.d/70.added.md
+++ b/python/changelog.d/70.added.md
@@ -1,0 +1,3 @@
+### Added
+
+- Applied automation-friendly Chromium launch defaults, including `--password-store=basic`, and added `extra_args` plus per-default opt-out controls.

--- a/python/src/browser_commander/browser/launcher.py
+++ b/python/src/browser_commander/browser/launcher.py
@@ -24,6 +24,8 @@ class LaunchOptions:
     slow_mo: int | None = None  # Default: 150 for Playwright, 0 for Selenium
     verbose: bool = False
     args: list[str] = field(default_factory=list)
+    extra_args: list[str] = field(default_factory=list)
+    ignore_default_args: bool | list[str] = field(default_factory=list)
     color_scheme: ColorScheme | None = None
 
 
@@ -33,6 +35,22 @@ class LaunchResult:
 
     browser: Any
     page: Any
+
+
+def resolve_chrome_args(
+    *,
+    args: list[str] | None = None,
+    extra_args: list[str] | None = None,
+    ignore_default_args: bool | list[str] | None = None,
+) -> list[str]:
+    """Resolve safe defaults followed by compatibility and extra arguments."""
+
+    if ignore_default_args is True:
+        defaults: list[str] = []
+    else:
+        ignored = set(ignore_default_args or [])
+        defaults = [argument for argument in CHROME_ARGS if argument not in ignored]
+    return [*defaults, *(args or []), *(extra_args or [])]
 
 
 async def launch_browser(options: LaunchOptions | None = None) -> LaunchResult:
@@ -55,7 +73,6 @@ async def launch_browser(options: LaunchOptions | None = None) -> LaunchResult:
     headless = options.headless
     slow_mo = options.slow_mo
     verbose = options.verbose
-    extra_args = options.args
     color_scheme = options.color_scheme
 
     # Set default user data directory
@@ -66,8 +83,11 @@ async def launch_browser(options: LaunchOptions | None = None) -> LaunchResult:
     if slow_mo is None:
         slow_mo = 150 if engine == "playwright" else 0
 
-    # Combine default CHROME_ARGS with custom args
-    chrome_args = CHROME_ARGS + extra_args
+    chrome_args = resolve_chrome_args(
+        args=options.args,
+        extra_args=options.extra_args,
+        ignore_default_args=options.ignore_default_args,
+    )
 
     if engine not in ("playwright", "selenium"):
         msg = f"Invalid engine: {engine}. Expected 'playwright' or 'selenium'"
@@ -94,7 +114,22 @@ async def launch_browser(options: LaunchOptions | None = None) -> LaunchResult:
             "chromium_sandbox": True,
             "viewport": None,
             "args": chrome_args,
-            "ignore_default_args": ["--enable-automation"],
+            "ignore_default_args": (
+                True
+                if options.ignore_default_args is True
+                else list(
+                    dict.fromkeys(
+                        [
+                            "--enable-automation",
+                            *(
+                                options.ignore_default_args
+                                if isinstance(options.ignore_default_args, list)
+                                else []
+                            ),
+                        ]
+                    )
+                )
+            ),
         }
         # Playwright supports color_scheme as a context-level launch option
         if color_scheme is not None:

--- a/python/src/browser_commander/browser/real_browser.py
+++ b/python/src/browser_commander/browser/real_browser.py
@@ -17,7 +17,7 @@ from typing import Any
 from urllib.request import urlopen
 
 from browser_commander.browser.connector import ConnectOptions, connect_browser
-from browser_commander.browser.launcher import LaunchResult
+from browser_commander.browser.launcher import LaunchResult, resolve_chrome_args
 from browser_commander.core.engine_detection import EngineType
 
 _MANAGED_ARGUMENTS = (
@@ -51,6 +51,8 @@ class RealBrowserOptions:
     remote_debugging_port: int = 0
     headless: bool = False
     args: list[str] = field(default_factory=list)
+    extra_args: list[str] = field(default_factory=list)
+    ignore_default_args: bool | list[str] = field(default_factory=list)
     startup_timeout: int = 30_000
     slow_mo: int | None = None
     timeout: int | None = None
@@ -295,6 +297,8 @@ def build_real_browser_args(
     remote_debugging_port: int = 0,
     headless: bool = False,
     args: list[str] | None = None,
+    extra_args: list[str] | None = None,
+    ignore_default_args: bool | list[str] | None = None,
 ) -> list[str]:
     """Build the protected command line for the installed browser process."""
 
@@ -306,8 +310,8 @@ def build_real_browser_args(
         msg = "remote_debugging_port must be an integer from 0 to 65535"
         raise ValueError(msg)
 
-    extra_args = args or []
-    for argument in extra_args:
+    custom_args = [*(args or []), *(extra_args or [])]
+    for argument in custom_args:
         if any(
             argument == managed or argument.startswith(f"{managed}=")
             for managed in _MANAGED_ARGUMENTS
@@ -315,14 +319,15 @@ def build_real_browser_args(
             msg = f"{argument} is managed by launch_real_browser"
             raise ValueError(msg)
 
+    default_args = resolve_chrome_args(ignore_default_args=ignore_default_args)
+
     return [
         "--remote-debugging-address=127.0.0.1",
         f"--remote-debugging-port={remote_debugging_port}",
         f"--user-data-dir={os.fspath(user_data_dir)}",
-        "--no-first-run",
-        "--no-default-browser-check",
+        *default_args,
         *(["--headless=new"] if headless else []),
-        *extra_args,
+        *custom_args,
     ]
 
 
@@ -466,6 +471,8 @@ async def launch_real_browser_with_dependencies(
         remote_debugging_port=options.remote_debugging_port,
         headless=options.headless,
         args=options.args,
+        extra_args=options.extra_args,
+        ignore_default_args=options.ignore_default_args,
     )
     browser_process = await _resolve(
         spawn_browser(executable_path, arguments, verbose=options.verbose)

--- a/python/src/browser_commander/core/constants.py
+++ b/python/src/browser_commander/core/constants.py
@@ -9,6 +9,7 @@ CHROME_ARGS: Final[list[str]] = [
     "--disable-session-crashed-bubble",
     "--hide-crash-restore-bubble",
     "--disable-infobars",
+    "--password-store=basic",
     "--no-first-run",
     "--no-default-browser-check",
     "--disable-crash-restore",

--- a/python/tests/unit/browser/test_launcher.py
+++ b/python/tests/unit/browser/test_launcher.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from browser_commander.browser.launcher import LaunchOptions
+from browser_commander.browser.launcher import LaunchOptions, resolve_chrome_args
 from browser_commander.core.constants import CHROME_ARGS
 
 
@@ -34,6 +34,14 @@ class TestLaunchOptions:
         options = LaunchOptions(args=custom_args)
         assert options.args == custom_args
 
+    def test_extra_args_and_ignored_defaults_are_stored(self):
+        options = LaunchOptions(
+            extra_args=["--lang=en-US"],
+            ignore_default_args=["--no-default-browser-check"],
+        )
+        assert options.extra_args == ["--lang=en-US"]
+        assert options.ignore_default_args == ["--no-default-browser-check"]
+
     def test_custom_user_data_dir(self):
         options = LaunchOptions(user_data_dir="/tmp/test-profile")
         assert options.user_data_dir == "/tmp/test-profile"
@@ -54,5 +62,23 @@ class TestChromeArgs:
 
     def test_chrome_args_includes_expected_defaults(self):
         assert "--disable-session-crashed-bubble" in CHROME_ARGS
+        assert "--password-store=basic" in CHROME_ARGS
         assert "--no-first-run" in CHROME_ARGS
         assert "--no-default-browser-check" in CHROME_ARGS
+
+    def test_resolves_additive_args_and_per_flag_opt_out(self):
+        args = resolve_chrome_args(
+            args=["--legacy-arg"],
+            extra_args=["--lang=en-US"],
+            ignore_default_args=["--no-default-browser-check"],
+        )
+
+        assert "--password-store=basic" in args
+        assert "--no-first-run" in args
+        assert "--no-default-browser-check" not in args
+        assert args[-2:] == ["--legacy-arg", "--lang=en-US"]
+
+    def test_can_ignore_all_defaults(self):
+        assert resolve_chrome_args(
+            extra_args=["--lang=en-US"], ignore_default_args=True
+        ) == ["--lang=en-US"]

--- a/python/tests/unit/browser/test_launcher.py
+++ b/python/tests/unit/browser/test_launcher.py
@@ -82,3 +82,9 @@ class TestChromeArgs:
         assert resolve_chrome_args(
             extra_args=["--lang=en-US"], ignore_default_args=True
         ) == ["--lang=en-US"]
+
+    def test_can_ignore_password_store_default_specifically(self):
+        args = resolve_chrome_args(ignore_default_args=["--password-store=basic"])
+
+        assert "--password-store=basic" not in args
+        assert "--no-first-run" in args

--- a/python/tests/unit/browser/test_real_browser.py
+++ b/python/tests/unit/browser/test_real_browser.py
@@ -35,11 +35,30 @@ def test_builds_protected_loopback_command() -> None:
         "--remote-debugging-address=127.0.0.1",
         "--remote-debugging-port=9333",
         "--user-data-dir=/tmp/browser-commander-dedicated",
+        "--disable-session-crashed-bubble",
+        "--hide-crash-restore-bubble",
+        "--disable-infobars",
+        "--password-store=basic",
         "--no-first-run",
         "--no-default-browser-check",
+        "--disable-crash-restore",
         "--headless=new",
         "--lang=en-US",
     ]
+
+
+def test_supports_additive_arguments_and_per_default_opt_out() -> None:
+    arguments = build_real_browser_args(
+        user_data_dir="/tmp/browser-commander-dedicated",
+        args=["--legacy-arg"],
+        extra_args=["--lang=en-US"],
+        ignore_default_args=["--no-first-run"],
+    )
+
+    assert "--password-store=basic" in arguments
+    assert "--no-first-run" not in arguments
+    assert "--no-default-browser-check" in arguments
+    assert arguments[-2:] == ["--legacy-arg", "--lang=en-US"]
 
 
 def test_rejects_default_profiles_and_managed_arguments(tmp_path: Any) -> None:

--- a/rust/README.md
+++ b/rust/README.md
@@ -78,10 +78,18 @@ use browser_commander::prelude::*;
 // Launch with chromiumoxide (CDP-based)
 let options = LaunchOptions::chromiumoxide()
     .headless(true)
-    .user_data_dir("~/.browser-data");
+    .user_data_dir("~/.browser-data")
+    .with_extra_args(vec!["--lang=en-US".to_string()])
+    .ignore_default_args(vec!["--disable-infobars".to_string()]);
 
 let result = launch_browser(options).await?;
 ```
+
+Browser Commander applies the documented
+[automation-friendly defaults](../docs/feature-parity.md#automation-friendly-launch-defaults),
+including `--password-store=basic` to avoid an extra OS credential dialog.
+`ignore_all_default_args()` omits every optional Browser Commander and engine
+default; `with_args()` remains a compatible append-only builder.
 
 ### Playwright and Puppeteer
 
@@ -160,6 +168,8 @@ Exactly one endpoint is required. When starting Chrome 136 or newer yourself,
 pass a non-default `--user-data-dir` together with the remote-debugging flag;
 Chrome intentionally disables remote debugging for its default data directory.
 Cookies can be supplied explicitly with `ConnectOptions::seed_cookies()`.
+Because connection is attach-only, it cannot retrofit launch flags. Start the
+external process with the documented defaults or use `launch_real_browser()`.
 
 ### Launch and Connect to an Installed Browser
 
@@ -175,6 +185,8 @@ let result = launch_real_browser(
     RealBrowserOptions::playwright()
         .channel("chrome")
         .user_data_dir("/tmp/browser-commander-profile")
+        .with_extra_args(vec!["--lang=en-US".to_string()])
+        .ignore_default_args(vec!["--disable-infobars".to_string()])
         .seed_cookies(vec![json!({
             "name": "session",
             "value": "saved",
@@ -192,6 +204,8 @@ profiles and custom arguments that override the loopback address, debugging
 port, or profile are rejected. `RealBrowserLaunchResult` owns a
 `browser_process` handle and terminates the spawned browser when dropped.
 `launch_and_connect_real_browser()` is an alias.
+The remote-debugging address, port, and profile remain managed; headless mode
+is opt-in and uses `--headless=new`.
 
 ### Navigation
 

--- a/rust/changelog.d/70.safe-browser-launch-defaults.md
+++ b/rust/changelog.d/70.safe-browser-launch-defaults.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+---
+
+### Added
+
+- Applied automation-friendly Chromium launch defaults, including `--password-store=basic`, and added extra-argument plus per-default opt-out builders.

--- a/rust/src/browser/launcher.rs
+++ b/rust/src/browser/launcher.rs
@@ -31,6 +31,12 @@ pub struct LaunchOptions {
     pub verbose: bool,
     /// Additional Chrome arguments.
     pub args: Vec<String>,
+    /// Additional Chrome arguments appended after the compatibility `args`.
+    pub extra_args: Vec<String>,
+    /// Browser Commander default arguments to omit.
+    pub ignore_default_args: Vec<String>,
+    /// Omit every Browser Commander and engine default argument.
+    pub ignore_all_default_args: bool,
     /// Installed browser channel for Playwright/Puppeteer (for example, `chrome`).
     pub channel: Option<String>,
     /// Explicit path to a Chrome or Chromium executable.
@@ -61,6 +67,9 @@ impl Default for LaunchOptions {
             slow_mo: 0,
             verbose: false,
             args: Vec::new(),
+            extra_args: Vec::new(),
+            ignore_default_args: Vec::new(),
+            ignore_all_default_args: false,
             channel: None,
             executable_path: None,
             color_scheme: None,
@@ -145,6 +154,24 @@ impl LaunchOptions {
         self
     }
 
+    /// Add Chrome arguments after the compatibility `args` field.
+    pub fn with_extra_args(mut self, args: Vec<String>) -> Self {
+        self.extra_args = args;
+        self
+    }
+
+    /// Omit selected Browser Commander defaults.
+    pub fn ignore_default_args(mut self, args: Vec<String>) -> Self {
+        self.ignore_default_args = args;
+        self
+    }
+
+    /// Omit every Browser Commander and engine default argument.
+    pub fn ignore_all_default_args(mut self) -> Self {
+        self.ignore_all_default_args = true;
+        self
+    }
+
     /// Select an installed browser channel for Playwright or Puppeteer.
     pub fn channel(mut self, channel: impl Into<String>) -> Self {
         self.channel = Some(channel.into());
@@ -189,8 +216,22 @@ impl LaunchOptions {
 
     /// Get all Chrome arguments (default + custom).
     pub fn all_chrome_args(&self) -> Vec<String> {
-        let mut all_args: Vec<String> = CHROME_ARGS.iter().map(|s| s.to_string()).collect();
+        let mut all_args: Vec<String> = if self.ignore_all_default_args {
+            Vec::new()
+        } else {
+            CHROME_ARGS
+                .iter()
+                .filter(|argument| {
+                    !self
+                        .ignore_default_args
+                        .iter()
+                        .any(|item| item == **argument)
+                })
+                .map(|argument| argument.to_string())
+                .collect()
+        };
         all_args.extend(self.args.clone());
+        all_args.extend(self.extra_args.clone());
         all_args
     }
 
@@ -322,6 +363,13 @@ async fn launch_chromiumoxide(
         .headless_mode(headless_mode)
         .args(options.all_chrome_args());
 
+    // Chromiumoxide only exposes an all-or-nothing switch for its own default
+    // layer. Disable that layer whenever the caller requests an omission so an
+    // engine-provided duplicate cannot silently re-add the selected flag.
+    if options.ignore_all_default_args || !options.ignore_default_args.is_empty() {
+        builder = builder.disable_default_args();
+    }
+
     if !options.sandbox {
         builder = builder.no_sandbox();
     }
@@ -410,6 +458,9 @@ mod tests {
         assert_eq!(options.slow_mo, 0);
         assert!(!options.verbose);
         assert!(options.args.is_empty());
+        assert!(options.extra_args.is_empty());
+        assert!(options.ignore_default_args.is_empty());
+        assert!(!options.ignore_all_default_args);
         assert!(options.channel.is_none());
         assert!(options.executable_path.is_none());
         assert!(options.node_executable.is_none());
@@ -473,7 +524,33 @@ mod tests {
         let args = options.all_chrome_args();
 
         assert!(args.contains(&"--disable-infobars".to_string()));
+        assert!(args.contains(&"--password-store=basic".to_string()));
         assert!(args.contains(&"--no-first-run".to_string()));
+    }
+
+    #[test]
+    fn all_chrome_args_appends_extra_args_and_ignores_selected_defaults() {
+        let options = LaunchOptions::default()
+            .with_args(vec!["--legacy-arg".to_string()])
+            .with_extra_args(vec!["--lang=en-US".to_string()])
+            .ignore_default_args(vec!["--no-default-browser-check".to_string()]);
+
+        let args = options.all_chrome_args();
+        assert!(args.contains(&"--password-store=basic".to_string()));
+        assert!(!args.contains(&"--no-default-browser-check".to_string()));
+        assert_eq!(
+            &args[args.len() - 2..],
+            ["--legacy-arg".to_string(), "--lang=en-US".to_string()]
+        );
+    }
+
+    #[test]
+    fn all_chrome_args_can_ignore_every_default() {
+        let options = LaunchOptions::default()
+            .ignore_all_default_args()
+            .with_extra_args(vec!["--lang=en-US".to_string()]);
+
+        assert_eq!(options.all_chrome_args(), ["--lang=en-US".to_string()]);
     }
 
     #[test]

--- a/rust/src/browser/launcher.rs
+++ b/rust/src/browser/launcher.rs
@@ -554,6 +554,16 @@ mod tests {
     }
 
     #[test]
+    fn all_chrome_args_can_ignore_password_store_default_specifically() {
+        let options = LaunchOptions::default()
+            .ignore_default_args(vec!["--password-store=basic".to_string()]);
+
+        let args = options.all_chrome_args();
+        assert!(!args.contains(&"--password-store=basic".to_string()));
+        assert!(args.contains(&"--no-first-run".to_string()));
+    }
+
+    #[test]
     fn all_chrome_args_includes_custom() {
         let options = LaunchOptions::default().with_args(vec!["--custom".to_string()]);
         let args = options.all_chrome_args();

--- a/rust/src/browser/node_bridge.rs
+++ b/rust/src/browser/node_bridge.rs
@@ -242,6 +242,11 @@ fn launch_params(options: &LaunchOptions, user_data_dir: &Path) -> Value {
         "slowMo": options.slow_mo,
         "verbose": options.verbose,
         "args": options.all_chrome_args(),
+        "ignoreDefaultArgs": if options.ignore_all_default_args {
+            Value::Bool(true)
+        } else {
+            json!(options.ignore_default_args)
+        },
         "colorScheme": options.color_scheme.as_ref().map(|cs| cs.as_str()),
         "sandbox": options.sandbox,
         "channel": options.channel,
@@ -538,6 +543,20 @@ mod tests {
 
         assert!(params["channel"].is_null());
         assert!(params["executablePath"].is_null());
+    }
+
+    #[test]
+    fn launch_params_forward_ignored_defaults() {
+        let options =
+            LaunchOptions::playwright().ignore_default_args(vec!["--no-first-run".to_string()]);
+
+        let params = launch_params(&options, Path::new("/tmp/browser-data"));
+
+        assert_eq!(params["ignoreDefaultArgs"][0], "--no-first-run");
+        assert!(!params["args"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("--no-first-run")));
     }
 
     #[test]

--- a/rust/src/browser/node_engine_bridge.js
+++ b/rust/src/browser/node_engine_bridge.js
@@ -64,6 +64,17 @@ function chromeArgs(params) {
   return args;
 }
 
+function ignoredDefaultArgs(params, includeEnableAutomation = false) {
+  if (params.ignoreDefaultArgs === true) {
+    return true;
+  }
+  const ignored = [...(params.ignoreDefaultArgs ?? [])];
+  if (includeEnableAutomation && !ignored.includes("--enable-automation")) {
+    ignored.unshift("--enable-automation");
+  }
+  return ignored;
+}
+
 function elementInfo(selector) {
   const el = document.querySelector(selector);
   if (!el) {
@@ -95,7 +106,7 @@ async function launchPlaywright(params) {
     chromiumSandbox: params.sandbox !== false,
     viewport: null,
     args: chromeArgs(params),
-    ignoreDefaultArgs: ["--enable-automation"],
+    ignoreDefaultArgs: ignoredDefaultArgs(params, true),
   };
 
   if (params.colorScheme !== null && params.colorScheme !== undefined) {
@@ -126,6 +137,10 @@ async function launchPuppeteer(params) {
     args: ["--start-maximized", ...chromeArgs(params)],
     userDataDir: params.userDataDir,
   };
+  const ignoredArgs = ignoredDefaultArgs(params);
+  if (ignoredArgs === true || ignoredArgs.length > 0) {
+    launchOptions.ignoreDefaultArgs = ignoredArgs;
+  }
   if (params.channel !== null && params.channel !== undefined) {
     launchOptions.channel = params.channel;
   }

--- a/rust/src/browser/real_browser.rs
+++ b/rust/src/browser/real_browser.rs
@@ -13,6 +13,7 @@ use tokio::net::TcpStream;
 
 use crate::browser::connector::{connect_browser, ConnectOptions};
 use crate::browser::launcher::{Browser, LaunchResult};
+use crate::core::constants::CHROME_ARGS;
 use crate::core::engine::{EngineAdapter, EngineType};
 
 const MANAGED_ARGUMENTS: [&str; 3] = [
@@ -38,6 +39,12 @@ pub struct RealBrowserOptions {
     pub headless: bool,
     /// Additional browser arguments.
     pub args: Vec<String>,
+    /// Additional browser arguments appended after the compatibility `args`.
+    pub extra_args: Vec<String>,
+    /// Browser Commander default arguments to omit.
+    pub ignore_default_args: Vec<String>,
+    /// Omit every Browser Commander default argument.
+    pub ignore_all_default_args: bool,
     /// Maximum time to wait for Chrome's `/json/version` endpoint.
     pub startup_timeout: Duration,
     /// Delay Playwright/Puppeteer operations by this many milliseconds.
@@ -66,6 +73,9 @@ impl Default for RealBrowserOptions {
             remote_debugging_port: 0,
             headless: false,
             args: Vec::new(),
+            extra_args: Vec::new(),
+            ignore_default_args: Vec::new(),
+            ignore_all_default_args: false,
             startup_timeout: Duration::from_secs(30),
             slow_mo: 0,
             timeout: None,
@@ -134,6 +144,24 @@ impl RealBrowserOptions {
     /// Set additional browser arguments.
     pub fn with_args(mut self, args: Vec<String>) -> Self {
         self.args = args;
+        self
+    }
+
+    /// Add browser arguments after the compatibility `args` field.
+    pub fn with_extra_args(mut self, args: Vec<String>) -> Self {
+        self.extra_args = args;
+        self
+    }
+
+    /// Omit selected Browser Commander defaults.
+    pub fn ignore_default_args(mut self, args: Vec<String>) -> Self {
+        self.ignore_default_args = args;
+        self
+    }
+
+    /// Omit every Browser Commander default argument.
+    pub fn ignore_all_default_args(mut self) -> Self {
+        self.ignore_all_default_args = true;
         self
     }
 
@@ -529,7 +557,8 @@ pub fn resolve_system_browser_executable(
 
 /// Build the protected command line for an installed browser process.
 pub fn build_real_browser_args(options: &RealBrowserOptions) -> Result<Vec<String>, anyhow::Error> {
-    for argument in &options.args {
+    let custom_args = options.args.iter().chain(&options.extra_args);
+    for argument in custom_args.clone() {
         if MANAGED_ARGUMENTS
             .iter()
             .any(|managed| argument == managed || argument.starts_with(&format!("{managed}=")))
@@ -544,13 +573,25 @@ pub fn build_real_browser_args(options: &RealBrowserOptions) -> Result<Vec<Strin
         "--remote-debugging-address=127.0.0.1".to_string(),
         format!("--remote-debugging-port={}", options.remote_debugging_port),
         format!("--user-data-dir={}", options.get_user_data_dir().display()),
-        "--no-first-run".to_string(),
-        "--no-default-browser-check".to_string(),
     ];
+    if !options.ignore_all_default_args {
+        arguments.extend(
+            CHROME_ARGS
+                .iter()
+                .filter(|argument| {
+                    !options
+                        .ignore_default_args
+                        .iter()
+                        .any(|item| item == **argument)
+                })
+                .map(|argument| argument.to_string()),
+        );
+    }
     if options.headless {
         arguments.push("--headless=new".to_string());
     }
     arguments.extend(options.args.clone());
+    arguments.extend(options.extra_args.clone());
     Ok(arguments)
 }
 

--- a/rust/src/core/constants.rs
+++ b/rust/src/core/constants.rs
@@ -13,6 +13,7 @@ pub const CHROME_ARGS: &[&str] = &[
     "--disable-session-crashed-bubble",
     "--hide-crash-restore-bubble",
     "--disable-infobars",
+    "--password-store=basic",
     "--no-first-run",
     "--no-default-browser-check",
     "--disable-crash-restore",
@@ -69,6 +70,7 @@ mod tests {
     #[test]
     fn chrome_args_contains_expected_arguments() {
         assert!(CHROME_ARGS.contains(&"--disable-infobars"));
+        assert!(CHROME_ARGS.contains(&"--password-store=basic"));
         assert!(CHROME_ARGS.contains(&"--no-first-run"));
         assert!(CHROME_ARGS.contains(&"--no-default-browser-check"));
     }

--- a/rust/tests/real_browser_api.rs
+++ b/rust/tests/real_browser_api.rs
@@ -17,11 +17,30 @@ fn real_browser_api_builds_protected_launch_arguments() {
     assert_eq!(arguments[0], "--remote-debugging-address=127.0.0.1");
     assert_eq!(arguments[1], "--remote-debugging-port=9333");
     assert_eq!(arguments[2], "--user-data-dir=dedicated-profile");
+    assert!(arguments.contains(&"--password-store=basic".to_string()));
     assert!(arguments.contains(&"--headless=new".to_string()));
     assert!(arguments.contains(&"--lang=en-US".to_string()));
 
     let _short_helper = launch_real_browser;
     let _compatible_helper = launch_and_connect_real_browser;
+}
+
+#[test]
+fn real_browser_api_supports_extra_args_and_per_default_opt_out() {
+    let options = RealBrowserOptions::chromiumoxide()
+        .user_data_dir("dedicated-profile")
+        .with_args(vec!["--legacy-arg".to_string()])
+        .with_extra_args(vec!["--lang=en-US".to_string()])
+        .ignore_default_args(vec!["--no-first-run".to_string()]);
+
+    let arguments = build_real_browser_args(&options).unwrap();
+    assert!(arguments.contains(&"--password-store=basic".to_string()));
+    assert!(!arguments.contains(&"--no-first-run".to_string()));
+    assert!(arguments.contains(&"--no-default-browser-check".to_string()));
+    assert_eq!(
+        &arguments[arguments.len() - 2..],
+        ["--legacy-arg".to_string(), "--lang=en-US".to_string()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- apply the same automation-friendly Chromium defaults in JavaScript, Python, and Rust, including `--password-store=basic`, first-run suppression, and the existing crash/infobar protections
- use the full defaults when launching an installed Chrome, Edge, Brave, or Chromium while keeping CDP on loopback with a dedicated, protected profile and `--headless=new` when requested
- add `extraArgs` / `extra_args` / Rust extra-argument builders and per-default opt-outs without breaking the existing `args` APIs
- document every default and its reason, the Chrome 136+ dedicated-profile requirement, and why attach-only connect APIs cannot retrofit flags onto an existing process
- add minor-release metadata for all three packages

## Root cause and reproduction

The shared launch argument lists did not include `--password-store=basic`, so a fresh Chrome-family profile could invoke the operating-system credential backend. The installed-browser launch helpers also hard-coded only the two first-run flags, and none of the language APIs resolved additive arguments together with per-default opt-outs.

Before this change, inspecting the default arguments produced by `launchBrowser` / `launch_browser` or `buildRealBrowserArgs` / `build_real_browser_args` showed that `--password-store=basic` was absent. The new unit regressions assert that it is present by default, custom arguments retain append order, individual defaults (including the password-store flag itself) can be omitted, and managed CDP/profile arguments remain protected.

`connectBrowser` / `connect_browser` attaches to an already-running process and therefore cannot alter its command line. The documentation now makes that boundary explicit and points callers to the real-browser launch helper or equivalent external flags.

## Verification

- JavaScript: 502 unit tests; ESLint; Prettier; duplication check; changeset status; API docs
- Python: 268 tests with coverage; Ruff check/format; mypy; wheel and sdist build; Twine validation
- Rust: all-feature tests and doctests with warnings denied; rustfmt; Clippy; API docs; optimized release build; package listing; file-size check
- Final working tree is clean and current `origin/main` is included

Fixes #70
